### PR TITLE
Feat/directory removal empty scan redirects

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -93,9 +93,7 @@ app.on("quit", () => {
   /* Synchrnously removes file upon quitting the app. Restarts/Shutdowns in
   Windows will not trigger this event */
   if (fs.existsSync(constants.scanResultsPath)){
-    console.log(constants.scanResultsPath)
     fs.rmSync(constants.scanResultsPath, { recursive: true }, err => {
-      console.log('Here')
       if (err) {
         console.error(`Error while deleting ${constants.scanResultsPath}.`);
       }

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -1,4 +1,5 @@
 const { app: electronApp, BrowserWindow, ipcMain } = require("electron");
+const fs = require("fs");
 const EventEmitter = require("events");
 const constants = require("./constants");
 const scanManager = require("./scanManager");
@@ -89,6 +90,17 @@ app.on("ready", async () => {
 });
 
 app.on("quit", () => {
+  /* Synchrnously removes file upon quitting the app. Restarts/Shutdowns in
+  Windows will not trigger this event */
+  if (fs.existsSync(constants.scanResultsPath)){
+    console.log(constants.scanResultsPath)
+    fs.rmSync(constants.scanResultsPath, { recursive: true }, err => {
+      console.log('Here')
+      if (err) {
+        console.error(`Error while deleting ${constants.scanResultsPath}.`);
+      }
+    })
+  }
   updateManager.killChildProcess();
   scanManager.killChildProcess();
 });

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -6,6 +6,7 @@ const { randomUUID } = require("crypto");
 const {
   enginePath,
   getPathVariable,
+  customFlowGeneratedScriptsPath,
   playwrightBrowsersPath,
 } = require("./constants");
 
@@ -84,6 +85,14 @@ const startScan = async (scanDetails) => {
         resolve({ success: false, statusCode: code, message: stdout });
       }
       currentChildProcess = null;
+      
+      if (fs.existsSync(customFlowGeneratedScriptsPath)) {
+        fs.rm(customFlowGeneratedScriptsPath, { recursive: true }, err => {
+          if (err) {
+            console.error(`Error while deleting ${customFlowGeneratedScriptsPath}.`);
+          }
+        });
+      }
     });
   });
 

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -70,6 +70,11 @@ const startScan = async (scanDetails) => {
     scan.on("exit", (code) => {
       const stdout = scan.stdout.read().toString().trim();
       if (code === 0) {
+        // Output from combine.js which prints the string "No pages were scanned" if crawled URL <= 0
+        if (stdout.includes("No pages were scanned")) {
+          resolve({success: false})
+        }
+
         const resultsPath = stdout
           .split("Results directory is at ")[1]
           .split(" ")[0];

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -11,7 +11,6 @@ const {
   backendPath,
   updateBackupsFolder,
   scanResultsPath,
-  customFlowGeneratedScriptsPath,
   phZipPath,
 } = require("./constants");
 const { silentLogger } = require("./logs");
@@ -73,12 +72,10 @@ const backUpData = async () => {
 
   if (os.platform() === "win32") {
     command = `mkdir "${updateBackupsFolder}" &&\
-    move "${scanResultsPath}" "${updateBackupsFolder}" &\
-    move "${customFlowGeneratedScriptsPath}" "${updateBackupsFolder}"`;
+    move "${scanResultsPath}" "${updateBackupsFolder}"`;
   } else {
     command = `mkdir '${updateBackupsFolder}' &&
-    (mv '${scanResultsPath}' '${updateBackupsFolder}' || true) &&
-    (mv '${customFlowGeneratedScriptsPath}' '${updateBackupsFolder}' || true)`;
+    (mv '${scanResultsPath}' '${updateBackupsFolder}' || true)`;
   }
 
   await execCommand(command);

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -41,6 +41,7 @@ const HomePage = ({ appVersion, setCompletedScanId }) => {
       navigate("/result");
       return;
     }
+
     if (urlErrorCodes.has(response.statusCode)) {
       let errorMessageToShow;
       switch (response.statusCode) {
@@ -61,8 +62,11 @@ const HomePage = ({ appVersion, setCompletedScanId }) => {
       navigate("/", { state: errorMessageToShow });
       return;
     }
-
-    navigate("/error");
+    /* When no pages were scanned (e.g. out of domain upon redirects when valid URL was entered),
+    redirects user to error page to going to result page with empty result
+    */
+   navigate("/error");
+   return;
   };
 
   return (


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- Removal of the custom_flow_scripts directory in the backend (if it exists) on every scan from the desktop application
- Checks for "No pages were scanned" message from cli.js which then leads to the error page to prevent the user from going to the result page and opening an empty report HTML.
- Deletes the results directory upon quitting the application.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've added/updated unit tests **(N.A.)**
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions **(N.A.)**
