### PR TITLE
create default export dir if not exist previously

### DIFF
--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -21,7 +21,7 @@ const {
   getDefaultEdgeDataDir,
 } = require("./constants");
 const { env, report } = require("process");
-const { readUserDataFromFile } = require("./userDataManager");
+const { readUserDataFromFile, createExportDir } = require("./userDataManager");
 const scanHistory = {};
 
 let currentChildProcess;
@@ -98,6 +98,8 @@ const startScan = async (scanDetails, scanEvent) => {
     scanDetails.email = userData.email;
     scanDetails.name = userData.name;
     scanDetails.exportDir = userData.exportDir;
+    const success = createExportDir(userData.exportDir);
+    if (!success) return  { failedToCreateExportDir: true }
   }
 
   if (!getDefaultChromeDataDir() && os.platform() ==='darwin') {

--- a/public/electron/userDataManager.js
+++ b/public/electron/userDataManager.js
@@ -17,10 +17,16 @@ const writeUserDetailsToFile = (userDetails) => {
     fs.writeFileSync(userDataFilePath, JSON.stringify(data));
 }
 
-const createExportDir = () => {
-    const exportDir = readUserDataFromFile().exportDir;
-    if (!fs.existsSync(exportDir)) {
-        fs.mkdirSync(exportDir, { recursive: true });
+const createExportDir = (path) => {
+    try {
+        if (!fs.existsSync(path)) {
+            fs.mkdirSync(path, { recursive: true });
+        }
+
+        return true;
+    } catch (error) {
+        console.error(error);
+        return false;
     }
 }
 
@@ -92,7 +98,7 @@ const setData = async (userDataEvent) => {
         })
         const userDetailsReceived = await userData; 
         writeUserDetailsToFile(userDetailsReceived);
-        createExportDir(); 
+        createExportDir(data.exportDir); 
     } else {
         userDataEvent.emit("userDataDoesExist");
     }
@@ -101,5 +107,6 @@ const setData = async (userDataEvent) => {
 module.exports = {
     init,
     setData, 
-    readUserDataFromFile
+    readUserDataFromFile,
+    createExportDir,
 }

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -102,6 +102,11 @@ const HomePage = ({ isProxy, appVersion, setCompletedScanId }) => {
       return;
     }
 
+    if (response.failedToCreateExportDir) {
+      navigate("/", { state: 'Unable to create download directory' });
+      return;
+    }
+
     if (response.success) {
       setCompletedScanId(response.scanId);
       if (scanDetails.scanType === 'Custom flow') {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- check that export directory exists and create if not before scan

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in package[-lock].json npm audit, portable installation on GitHub Actions