### PR TITLE
Allow users to replay custom flow scripts in error page 

### DIFF
--- a/src/MainWindow/CustomFlow/CustomFlow.scss
+++ b/src/MainWindow/CustomFlow/CustomFlow.scss
@@ -77,6 +77,7 @@
         margin-right: 2rem;
         height: fit-content;
         box-shadow: 0px 1px 2px 0px rgba(16, 24, 40, 0.06), 0px 1px 3px 0px rgba(16, 24, 40, 0.10);
+        border-radius: 4px;
     }
     
     .progress-step-container h4 {

--- a/src/MainWindow/CustomFlow/index.jsx
+++ b/src/MainWindow/CustomFlow/index.jsx
@@ -25,20 +25,14 @@ const CustomFlowPage = ({ completedScanId, setCompletedScanId }) => {
     const [isReplay, setIsReplay] = useState(false);
 
     useEffect(() => {
-        console.log("state.scanDetails: ", state.scanDetails);
-        if (state.scanDetails) {
-          console.log("entered scan details");
+        if (state && state.scanDetails) {
           setScanDetails(state.scanDetails);
         }
 
-        console.log("is replay: ", state.isReplay);
-        if (state.isReplay) {
-          console.log("entered is replay");
+        if (state && state.isReplay) {
           setIsReplay(true);
           const generatedScript = window.localStorage.getItem("latestCustomFlowGeneratedScript");
           const scanDetails = JSON.parse(window.localStorage.getItem("latestCustomFlowScanDetails"));
-          console.log("local storage gen script: ", generatedScript);
-          console.log("local storage scan details: ", scanDetails);
           setGeneratedScript(generatedScript);
           setScanDetails(scanDetails);
           setStep(2);
@@ -67,6 +61,8 @@ const CustomFlowPage = ({ completedScanId, setCompletedScanId }) => {
         const response = await services.startScan(scanDetails);
 
         if (response.success) {
+          window.localStorage.setItem("latestCustomFlowGeneratedScript", response.generatedScript); 
+          window.localStorage.setItem("latestCustomFlowScanDetails", JSON.stringify(scanDetails));
           setGeneratedScript(response.generatedScript);
           setLoading(false);
           setDone(true);
@@ -114,25 +110,23 @@ const CustomFlowPage = ({ completedScanId, setCompletedScanId }) => {
     }
 
     const startReplaying = async () => {
-        const response = await window.services.startReplay(generatedScript, scanDetails, isReplay);
+      const response = await window.services.startReplay(generatedScript, scanDetails, isReplay);
 
-        if (response.success) {
-            setCompletedScanId(response.scanId);   
-            setLoading(false);
-            setDone(true);
-            return;         
-        }
+      if (response.success) {
+          setCompletedScanId(response.scanId);   
+          setLoading(false);
+          setDone(true);
+          return;         
+      }
 
-        navigate("/error");
-        return;
+      navigate("/error", {state: { isCustomScan: true }});
+      return;
     } 
 
     const generateReport =  () => {
       if (customFlowLabel.length > 0) {
         window.services.generateReport(customFlowLabel, completedScanId); 
       }
-      window.localStorage.setItem("latestCustomFlowGeneratedScript", generatedScript); 
-      window.localStorage.setItem("latestCustomFlowScanDetails", JSON.stringify(scanDetails));
       navigate("/result", {state: { isCustomScan: true }});
       return;
     }

--- a/src/MainWindow/ErrorPage/ErrorPage.scss
+++ b/src/MainWindow/ErrorPage/ErrorPage.scss
@@ -17,4 +17,15 @@
     margin-bottom: 1.5rem;
     font-size: 1rem;
   }
+
+  #back-to-home-btn {
+    white-space: nowrap;
+    margin-top: 1rem;
+    margin-right: 1rem;
+    border: 0;
+    border-bottom: 1px solid #785ef0;
+    color: #785ef0;
+    line-height: 1.5rem;
+    background-color: transparent;
+  }
 }

--- a/src/MainWindow/ErrorPage/index.jsx
+++ b/src/MainWindow/ErrorPage/index.jsx
@@ -1,11 +1,36 @@
 import Button from "../../common/components/Button";
 import ButtonSvgIcon from "../../common/components/ButtonSvgIcon";
 import "./ErrorPage.scss";
-import { useNavigate } from "react-router";
+import returnIcon from "../../assets/return.svg";
+import { useNavigate, useLocation } from "react-router";
 import { ReactComponent as ExclamationCircleIcon } from "../../assets/exclamation-circle.svg";
+import { useState, useEffect } from "react";
 
 const ErrorPage = () => {
+  const { state } = useLocation();
   const navigate = useNavigate();
+  const [isCustomScan, setIsCustomScan] = useState(false);
+
+  useEffect(() => {
+    if (state && state.isCustomScan) {
+      setIsCustomScan(state.isCustomScan);
+    }
+  }, []);
+
+  const replayCustomFlow = async () => {
+    navigate("/custom_flow", { state: { isReplay: true } });
+    return;
+  };
+
+  const handleBackToHome = () => {
+    if (isCustomScan) {
+      window.services.cleanUpCustomFlowScripts();
+      window.localStorage.removeItem("latestCustomFlowGeneratedScript");
+      window.localStorage.removeItem("latestCustomFlowScanDetails");
+    }
+    navigate("/");
+    return;
+  }
 
   return (
     <div id="error-page">
@@ -15,9 +40,21 @@ const ErrorPage = () => {
       />
       {/* <i className="bi bi-exclamation-circle"></i> */}
       <h1>Something went wrong! Please try again.</h1>
-      <Button role="link" type="primary" onClick={() => navigate("/")}>
-        Try again
-      </Button>
+      {isCustomScan
+      ? (
+        <>
+        <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>
+          <img src={returnIcon}></img>
+          &nbsp;Back To Home
+        </button>
+        <Button id="replay-btn" type="primary" onClick={replayCustomFlow}>
+          Replay
+        </Button>
+        </>
+      )
+      : <Button role="link" type="primary" onClick={handleBackToHome}>
+          Try Again
+        </Button>}
     </div>
   );
 };

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -85,23 +85,6 @@ const ResultPage = ({ completedScanId: scanId }) => {
   };
 
   const replayCustomFlow = async () => {
-    // need scan details and generated
-    // store latest generated script in local storage or pass as variable
-    // what to display if user replays :>
-
-    // const generatedScript = window.localStorage.getItem("latestCustomFlowGeneratedScript");
-    // const scanDetails = window.localStorage.getItem("latestCustomFlowScanDetails");
-    // const response = await window.services.startReplay(generatedScript, scanDetails);
-    // if (response.success) {
-    //   console.log(response);
-    //   setCompletedScanId(response.scanId);
-    //   setLoading(false);
-    //   setDone(true);
-    //   return;
-    // }
-
-    // navigate("/error");
-    // return;
     navigate("/custom_flow", { state: { isReplay: true } });
     return;
   };


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Replay button in error page when custom flow replay step fails 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [X] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1 reviewer
- [X] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
