### PR TITLE
Fixinnosetup long file path

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           $PHbackendUrl = "https://github.com/GovTechSG/purple-hats/releases/latest/download/purple-hats-portable-windows.zip"
           $BEdestinationPath = "${{github.workspace}}\PHLatest.zip"
-          $BEextractPath = "${{github.workspace}}\Purple HATS Backend"
+          $BEextractPath = "C:\a\Purple HATS Backend"
           Invoke-WebRequest -Uri $PHbackendUrl -OutFile $BEdestinationPath
           Expand-Archive -Path $BEdestinationPath -DestinationPath $BEextractPath -Force
           Remove-Item -Path $BEdestinationPath

--- a/hats_for_windows.iss
+++ b/hats_for_windows.iss
@@ -15,7 +15,7 @@ DefaultDirName=C:\Program Files\Purple HATS Desktop
 DisableDirPage=yes
 ChangesAssociations=yes
 DisableProgramGroupPage=yes
-LicenseFile=Purple HATS-win32-x64\LICENSE
+; LicenseFile=Purple HATS-win32-x64\LICENSE
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 Compression=lzma
@@ -29,8 +29,8 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "Purple HATS-win32-x64\*"; DestDir: "{app}\Purple HATS Frontend"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "Purple HATS Backend\*"; DestDir: "{app}\Purple HATS Backend"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "Purple HATS-win32-x64\*"; DestDir: "\\?\{app}\Purple HATS Frontend"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "C:\a\Purple HATS Backend\*"; DestDir: "\\?\{app}\Purple HATS Backend"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- Fix the behaviour of InnoSetup compile for long file paths in [Source].

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [x] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
