### PR TITLE
Add checkbox for users to include/exclude element screenshots in report

### DIFF
--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -54,9 +54,15 @@ const getScanOptions = (details) => {
     name,
     exportDir,
     maxConcurrency,
-    falsePositive
+    falsePositive,
+    includeScreenshots,
   } = details;
   const options = ["-c", scanType, "-u", url, "-k", `${name}:${email}`, "-i", fileTypes];
+
+  if (!includeScreenshots) {
+    options.push('-a');
+    options.push('none');
+  }
 
   if (customDevice) {
     options.push("-d", customDevice);

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -204,6 +204,21 @@ const AdvancedScanOptions = ({
               />
             </div>
           </div>
+          <div id='screenshots-toggle-group'>
+            <input 
+              type="checkbox"
+              id="screenshots-toggle" 
+              aria-describedby="screenshots-tooltip"
+              checked={advancedOptions.includeScreenshots}
+              onChange={handleSetAdvancedOption(
+                "includeScreenshots", 
+                (e) => e.target.checked
+              )} 
+            /> 
+            <label htmlFor="screenshots-toggle">
+              Include element screenshots in the report
+            </label>
+          </div>
           <hr />
           <div className="user-input-group">
             <label id="download-folder-label" className="bold-text">

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -139,18 +139,21 @@
   }
 
   #max-concurrency-toggle-group,
-  #false-positive-toggle-group {
+  #false-positive-toggle-group,
+  #screenshots-toggle-group {
     display: flex;
     align-items: center;
     height: 1.75rem;
   }
 
-  #false-positive-toggle-group {
+  #false-positive-toggle-group,
+  #max-concurrency-toggle-group {
     margin-bottom: 1rem;
   }
 
   #max-concurrency-toggle,
-  #false-positive-toggle {
+  #false-positive-toggle,
+  #screenshots-toggle {
     appearance: none;
     background-color: #fff;
     background-position: 50%;
@@ -164,12 +167,14 @@
   }
 
   #max-concurrency-toggle:checked,
-  #false-positive-toggle:checked {
+  #false-positive-toggle:checked,
+  #screenshots-toggle:checked {
     background-color: #785ef0;
   }
 
   #max-concurrency-toggle:checked[type="checkbox"],
-  #false-positive-toggle:checked[type="checkbox"] {
+  #false-positive-toggle:checked[type="checkbox"],
+  #screenshots-toggle:checked[type="checkbox"] {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='%23fff' viewBox='0 0 16 16'%3E%3Cpath d='M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z'/%3E%3C/svg%3E");
   }
 

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -32,6 +32,7 @@ const InitScanForm = ({ isProxy, startScan, prevUrlErrorMessage }) => {
     // scanInBackground: false,
     maxConcurrency: false, 
     falsePositive: false,
+    includeScreenshots: true,
   });
 
   const togglePageLimitAdjuster = () => {

--- a/src/services.js
+++ b/src/services.js
@@ -27,7 +27,8 @@ const startScan = async (scanDetails) => {
     // scanInBackground,
     browser,
     maxConcurrency,
-    falsePositive
+    falsePositive,
+    includeScreenshots,
   } = scanDetails;
 
   currentScanUrl = scanUrl;
@@ -40,6 +41,7 @@ const startScan = async (scanDetails) => {
     maxConcurrency: maxConcurrency,
     falsePositive: falsePositive,
     fileTypes: fileTypes[selectedFileTypes],
+    includeScreenshots,
   };
 
   if (selectedScanType !== Object.keys(scanTypes)[2]) {


### PR DESCRIPTION
This PR adds...
- Checkbox within advanced scan options for users to choose whether element screenshots are included in the report

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
