### PR TITLE
Open what's new modal upon update to latest version, bug fixes

### DIFF
--- a/public/electron/constants.js
+++ b/public/electron/constants.js
@@ -83,7 +83,6 @@ const defaultExportDir = path.join(os.homedir(), "Documents", "Purple HATS");
 const indexPath = path.join(__dirname, "..", "..", "build", "index.html");
 
 const playwrightBrowsersPath = path.join(backendPath, "ms-playwright");
-const javaPath = path.join(backendPath, 'jdk\\bin');
 
 const getPathVariable = () => {
   if (os.platform() === "win32") {
@@ -649,5 +648,4 @@ module.exports = {
   forbiddenCharactersInDirPath,
   maxLengthForDirName,
   versionComparator,
-  javaPath,
 };

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -14,7 +14,6 @@ const {
   getPathVariable,
   customFlowGeneratedScriptsPath,
   playwrightBrowsersPath,
-  javaPath,
   resultsPath,
   scanResultsPath,
   forbiddenCharactersInDirPath,
@@ -145,7 +144,6 @@ const startScan = async (scanDetails, scanEvent) => {
         env: {
           ...process.env,
           RUNNING_FROM_PH_GUI: true,
-          JAVA_HOME: `${javaPath}`,
           PLAYWRIGHT_BROWSERS_PATH: `${playwrightBrowsersPath}`,
           PATH: getPathVariable(),
         },
@@ -252,7 +250,6 @@ const startReplay = async (generatedScript, scanDetails, scanEvent, isReplay) =>
         ...process.env,
         RUNNING_FROM_PH_GUI: true,
         PLAYWRIGHT_BROWSERS_PATH: `${playwrightBrowsersPath}`,
-        JAVA_HOME: `${javaPath}`,
         PATH: getPathVariable(),
       },
     });

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -21,7 +21,7 @@ const {
   versionComparator,
 } = require("./constants");
 const { silentLogger } = require("./logs");
-const { readUserDataFromFile } = require("./userDataManager");
+const { writeUserDetailsToFile } = require("./userDataManager");
 
 let currentChildProcess;
 
@@ -357,6 +357,7 @@ const run = async (updaterEventEmitter) => {
             const isInstallerScriptLaunched =
               await spawnScriptToLaunchInstaller();
             if (isInstallerScriptLaunched) {
+              writeUserDetailsToFile({ firstLaunchOnUpdate: true });
               updaterEventEmitter.emit("installerLaunched");
             }
           }
@@ -396,6 +397,8 @@ const run = async (updaterEventEmitter) => {
         try {
           await downloadAndUnzipFrontendMac();
           currentChildProcess = null;
+
+          writeUserDetailsToFile({ firstLaunchOnUpdate: true });
           updaterEventEmitter.emit("restartTriggered");
         } catch (e) {
           silentLogger.error(e.toString());

--- a/public/electron/userDataManager.js
+++ b/public/electron/userDataManager.js
@@ -12,9 +12,8 @@ const readUserDataFromFile = () => {
 
 const writeUserDetailsToFile = (userDetails) => {
     const data = readUserDataFromFile();
-    data.name = userDetails.name; 
-    data.email = userDetails.email;
-    fs.writeFileSync(userDataFilePath, JSON.stringify(data));
+    const newData = { ...data, ...userDetails };
+    fs.writeFileSync(userDataFilePath, JSON.stringify(newData));
 }
 
 const createExportDir = (path) => {
@@ -107,5 +106,6 @@ module.exports = {
     init,
     setData, 
     readUserDataFromFile,
+    writeUserDetailsToFile,
     createExportDir,
 }

--- a/src/App.css
+++ b/src/App.css
@@ -136,16 +136,12 @@ a:hover {
 
 .onboarding-modal .modal-img-container {
   height: 160px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   margin-bottom: 1rem;
 }
 
 .modal {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   background-color: rgba(0, 0, 0, 0.2);
 }
 

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -7,6 +7,7 @@ import { ReactComponent as ChevronDownIcon } from "../../assets/chevron-down.svg
 import questionMarkIcon from "../../assets/question-mark.svg";
 import ButtonSvgIcon from "../../common/components/ButtonSvgIcon";
 import ToolTip from "../../common/components/ToolTip";
+import { getDefaultAdvancedOptions } from "../../common/constants";
 
 const AdvancedScanOptions = ({
   isProxy,
@@ -62,14 +63,14 @@ const AdvancedScanOptions = ({
       newOptions[option] = val;
       setAdvancedOptions(newOptions);
 
-      if (
-        newOptions.scanType === scanTypeOptions[0] &&
-        newOptions.viewport === viewportOptions.desktop
-      ) {
-        setAdvancedOptionsDirty(false);
-      } else {
-        setAdvancedOptionsDirty(true);
-      }
+      // check if new options are the default
+      const defaultAdvancedOptions = getDefaultAdvancedOptions(isProxy);
+      const isNewOptionsDefault = Object.keys(defaultAdvancedOptions)
+        .reduce((isDefaultSoFar, key) => {
+          return isDefaultSoFar && defaultAdvancedOptions[key] === newOptions[key];
+        }, true);
+      
+      setAdvancedOptionsDirty(!isNewOptionsDefault);
     };
 
   return (
@@ -155,6 +156,21 @@ const AdvancedScanOptions = ({
               onChange={handleSetAdvancedOption("fileTypes")}
             />
           )}
+          <div id='screenshots-toggle-group'>
+            <input 
+              type="checkbox"
+              id="screenshots-toggle" 
+              aria-describedby="screenshots-tooltip"
+              checked={advancedOptions.includeScreenshots}
+              onChange={handleSetAdvancedOption(
+                "includeScreenshots", 
+                (e) => e.target.checked
+              )} 
+            /> 
+            <label htmlFor="screenshots-toggle">
+              Include screenshots
+            </label>
+          </div>
           <div id='false-positive-toggle-group'>
               <input 
                 type="checkbox"
@@ -203,21 +219,6 @@ const AdvancedScanOptions = ({
                 alt="tooltip icon for slow scan mode"
               />
             </div>
-          </div>
-          <div id='screenshots-toggle-group'>
-            <input 
-              type="checkbox"
-              id="screenshots-toggle" 
-              aria-describedby="screenshots-tooltip"
-              checked={advancedOptions.includeScreenshots}
-              onChange={handleSetAdvancedOption(
-                "includeScreenshots", 
-                (e) => e.target.checked
-              )} 
-            /> 
-            <label htmlFor="screenshots-toggle">
-              Include element screenshots in the report
-            </label>
           </div>
           <hr />
           <div className="user-input-group">

--- a/src/MainWindow/HomePage/EditUserDetailsModal.jsx
+++ b/src/MainWindow/HomePage/EditUserDetailsModal.jsx
@@ -10,6 +10,7 @@ const EditUserDetailsModal = ({
   initialName,
   initialEmail,
   setShowEditDataModal,
+  setUserData,
 }) => {
   const [editedName, setEditedName] = useState(initialName);
   const [editedEmail, setEditedEmail] = useState(initialEmail);
@@ -26,6 +27,7 @@ const EditUserDetailsModal = ({
   const handleEditUserData = () => {
     window.services.editUserData({ name: editedName, email: editedEmail });
     setShowEditDataModal(false);
+    setUserData((userData) => ({ ...userData, name: editedName, email: editedEmail }))
   };
 
   const setShowModal = (show) => {

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -147,7 +147,7 @@
   }
 
   #false-positive-toggle-group,
-  #max-concurrency-toggle-group {
+  #screenshots-toggle-group {
     margin-bottom: 1rem;
   }
 

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import Button from "../../common/components/Button";
 import AdvancedScanOptions from "./AdvancedScanOptions";
-import { scanTypes, viewportTypes, devices, fileTypes } from "../../common/constants";
+import { scanTypes, viewportTypes, devices, fileTypes, getDefaultAdvancedOptions } from "../../common/constants";
 import ButtonSvgIcon from "../../common/components/ButtonSvgIcon";
 import { ReactComponent as ChevronUpIcon } from "../../assets/chevron-up.svg";
 import { ReactComponent as ChevronDownIcon } from "../../assets/chevron-down.svg";
@@ -23,17 +23,7 @@ const InitScanForm = ({ isProxy, startScan, prevUrlErrorMessage }) => {
   const viewportOptions = viewportTypes;
   const deviceOptions = isProxy ? [] : Object.keys(devices);
 
-  const [advancedOptions, setAdvancedOptions] = useState({
-    scanType: scanTypeOptions[0],
-    viewport: viewportOptions.desktop,
-    fileTypes: fileTypesOptions[0],
-    device: deviceOptions[0],
-    viewportWidth: "320",
-    // scanInBackground: false,
-    maxConcurrency: false, 
-    falsePositive: false,
-    includeScreenshots: true,
-  });
+  const [advancedOptions, setAdvancedOptions] = useState(getDefaultAdvancedOptions(isProxy));
 
   const togglePageLimitAdjuster = () => {
     if (!openPageLimitAdjuster) {

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -1,6 +1,7 @@
 import Modal from "../../common/components/Modal";
 import boxRightArrow from '../../assets/box-right-arrow.png';
 import { useEffect, useRef } from "react";
+import { handleClickLink } from "../../common/constants";
 
 const WhatsNewModalBody = ({ latestReleaseNotes }) => {
   const bodyRef = useRef(null);
@@ -41,7 +42,8 @@ const WhatsNewModal = ({ showModal, setShowModal, latestVersion, latestReleaseNo
         <a
           role="link"
           className="link me-auto" // to align to left
-          href="https://github.com/GovTechSG/purple-hats-desktop/releases"
+          href="#"
+          onClick={(e) => {handleClickLink(e, "https://github.com/GovTechSG/purple-hats-desktop/releases/")}}
         >
           See previous versions
           <img id="box-arrow-right" src={boxRightArrow}></img>

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -33,7 +33,6 @@ const WhatsNewModal = ({ showModal, setShowModal, latestVersion, latestReleaseNo
   return (
     <Modal
       id="whats-new-modal"
-      modalSizeClass="mh-100"
       showModal={showModal}
       showHeader={true}
       modalTitle={"What's new in v" + latestVersion}

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -20,12 +20,10 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
   const [prevUrlErrorMessage, setPrevUrlErrorMessage] = useState(
     location.state
   );
-  // const [email, setEmail] = useState("");
-  // const [name, setName] = useState("");
-  // const [browser, setBrowser] = useState(null);
   const [{ name, email, browser }, setUserData] = useState({
     name: "", 
-    email: ""
+    email: "",
+    browser: null,
   });
   const [showBasicAuthModal, setShowBasicAuthModal] = useState(false);
   const [showEditDataModal, setShowEditDataModal] = useState(false);
@@ -46,18 +44,6 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
       setShowNoChromeErrorModal(true);
     } 
   }, [prevUrlErrorMessage]);
-
-  // useEffect(() => {
-  //   const getUserData = async () => {
-  //     const userData = await services.getUserData();
-  //     setBrowser(userData["browser"]);
-  //     setEmail(userData["email"]);
-  //     setName(userData["name"]);
-  //     setShowWhatsNewModal(!!userData["firstLaunchOnUpdate"]);
-  //   };
-
-  //   getUserData();
-  // });
 
   useEffect(() => {
     const getUserData = async () => {

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -20,9 +20,13 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
   const [prevUrlErrorMessage, setPrevUrlErrorMessage] = useState(
     location.state
   );
-  const [email, setEmail] = useState("");
-  const [name, setName] = useState("");
-  const [browser, setBrowser] = useState(null);
+  // const [email, setEmail] = useState("");
+  // const [name, setName] = useState("");
+  // const [browser, setBrowser] = useState(null);
+  const [{ name, email, browser }, setUserData] = useState({
+    name: "", 
+    email: ""
+  });
   const [showBasicAuthModal, setShowBasicAuthModal] = useState(false);
   const [showEditDataModal, setShowEditDataModal] = useState(false);
   const [showNoChromeErrorModal, setShowNoChromeErrorModal] = useState(false);
@@ -43,16 +47,29 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
     } 
   }, [prevUrlErrorMessage]);
 
+  // useEffect(() => {
+  //   const getUserData = async () => {
+  //     const userData = await services.getUserData();
+  //     setBrowser(userData["browser"]);
+  //     setEmail(userData["email"]);
+  //     setName(userData["name"]);
+  //     setShowWhatsNewModal(!!userData["firstLaunchOnUpdate"]);
+  //   };
+
+  //   getUserData();
+  // });
+
   useEffect(() => {
     const getUserData = async () => {
       const userData = await services.getUserData();
-      setBrowser(userData["browser"]);
-      setEmail(userData["email"]);
-      setName(userData["name"]);
+      setUserData(userData);
+      // to show what's new modal on successful update to latest version
+      setShowWhatsNewModal(!!userData["firstLaunchOnUpdate"] && appVersionInfo.isLatest);
+      window.services.editUserData({ firstLaunchOnUpdate: false });
     };
 
     getUserData();
-  });
+  }, []);
 
   useEffect(() => {
     const checkChromeExists = async () => {
@@ -226,6 +243,7 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
             setShowEditDataModal={setShowEditDataModal}
             initialName={name}
             initialEmail={email}
+            setUserData={setUserData}
           />
         </>
       )}

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -76,6 +76,20 @@ export const devices = {
   "Motorola Moto G4": "Moto G4",
 };
 
+export const getDefaultAdvancedOptions = (isProxy) => {
+  const deviceOptions = isProxy ? [] : Object.keys(devices);
+  return {
+    scanType: Object.keys(scanTypes)[0],
+    viewport: viewportTypes.desktop,
+    fileTypes: Object.keys(fileTypes)[0],
+    device: deviceOptions[0],
+    viewportWidth: "320",
+    maxConcurrency: false, 
+    falsePositive: false,
+    includeScreenshots: true,
+  }
+};
+
 // exit codes returned by Purple HATS cli when there is an error with the URL provided
 export const cliErrorCodes = new Set([11, 12, 13, 14, 15, 16, 17]);
 export const cliErrorTypes = {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Display the what's new modal when user first opens the app after an update to the latest version
- Fix bug where UI does not properly feedback when the user has modified the default advanced options
- Remove redundant javaPath constant (path to java is set in getPathVariable() instead)
- Styling changes for modal

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
