### PR TITLE
Improve the send email button on the Complete scan page and allow user to send more than once

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,7 +45,7 @@ button.primary:active {
 }
 
 button.secondary {
-  padding: 0.25rem 2rem;
+  padding: 0.25rem 1rem;
   border: 1px solid #785ef0;
   background-color: #fff;
   border-radius: 4px;

--- a/src/App.css
+++ b/src/App.css
@@ -63,9 +63,10 @@ button.secondary:active {
   color: #472bc4;
 }
 
-button.primary:disabled {
+button.primary:disabled, button.secondary:disabled {
   background-color: #e7ecee!important;
   color: #97adb5!important;
+  border: none!important;
 }
 
 .download-dropdown-btn:disabled {

--- a/src/MainWindow/ResultPage/EditMailDetailsModal.jsx
+++ b/src/MainWindow/ResultPage/EditMailDetailsModal.jsx
@@ -107,7 +107,7 @@ const EditMailDetailsModal = ({
         <button
           type="submit"
           form="edit-mail-details-form"
-          className={`primarymodal-button`}
+          className={`primary modal-button`}
           disabled={isSubmitDisabled}
         >
           Send Mail

--- a/src/MainWindow/ResultPage/ResultPage.scss
+++ b/src/MainWindow/ResultPage/ResultPage.scss
@@ -51,6 +51,7 @@
   #btn-container {
     display: flex;
     flex-direction: row;
+    gap: 2rem;
   }
 
   #download-content {

--- a/src/MainWindow/ResultPage/ResultPage.scss
+++ b/src/MainWindow/ResultPage/ResultPage.scss
@@ -147,10 +147,6 @@
     margin-right: 0.5rem;
   }
 
-  .modal-content {
-    width: 700px;
-  }
-
   .user-form-field {
     grid-template-columns: 20% 80%;
     margin-bottom: 1rem;

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -111,9 +111,14 @@ const ResultPage = ({ completedScanId: scanId }) => {
       { subject: finalSubject, emailAddresses: emails },
       scanId
     );
+    
     if (response.success) {
       alert("Report successfully mailed");
       setMailStatus("sent");
+
+      setTimeout(() => {
+        setMailStatus('send');
+      }, 1500);
     } else {
       alert("Report failed to mail");
       setMailStatus("send");
@@ -132,10 +137,50 @@ const ResultPage = ({ completedScanId: scanId }) => {
               {resultsPath}
             </a>.
           </p>
-          <Button id="view-button" type="primary" onClick={handleViewReport}>
-           <img alt="" src={boxArrowUpRightIcon}></img>
-            View report
-          </Button>
+          <div id="btn-container">
+            <Button id="view-button" type="primary" onClick={handleViewReport}>
+            <img alt="" src={boxArrowUpRightIcon}></img>
+              View report
+            </Button>
+            {/* {isWindows && isEvent && ( */}
+            { true && 
+                <>
+                  {mailStatus === "send" && (
+                  <Button
+                    id="mail-report-button"
+                    type="secondary"
+                    onClick={() => setShowEditMailDetailsModal(true)}
+                  >
+                    <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
+                    Email report
+                  </Button>
+                  )}
+                  {mailStatus === "sending" && (
+                    <Button
+                      id="mail-report-button"
+                      type="secondary"
+                      disabled="disabled"
+                    >
+                      <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
+                      Sending mail...
+                    </Button>
+                  )}
+                  {mailStatus === "sent" && (
+                    <Button
+                      id="mail-report-button"
+                      type="secondary"
+                      disabled="disabled"
+                    >
+                      <ButtonSvgIcon
+                        svgIcon={<MailSuccessIcon />}
+                        className={`mail-icon`}
+                      />
+                      Report mailed
+                    </Button>
+                  )}
+              </>
+          }
+          </div>
           <hr class="my-5"/>
           <div id="other-actions">
             <h2>Other actions</h2>
@@ -163,46 +208,6 @@ const ResultPage = ({ completedScanId: scanId }) => {
               </li>
             </ul>
           </div>
-          {isWindows && isEvent && (
-            <div id="btn-container">
-              {mailStatus === "send" && (
-                <Button
-                  id="mail-report-button"
-                  type="primary"
-                  className="bold-text"
-                  onClick={() => setShowEditMailDetailsModal(true)}
-                >
-                  <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
-                  Mail report
-                </Button>
-              )}
-              {mailStatus === "sending" && (
-                <Button
-                  id="mail-report-button"
-                  type="primary"
-                  className="bold-text"
-                  disabled="disabled"
-                >
-                  <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
-                  Sending mail...
-                </Button>
-              )}
-              {mailStatus === "sent" && (
-                <Button
-                  id="mail-report-button"
-                  type="primary"
-                  disabled="disabled"
-                >
-                  <ButtonSvgIcon
-                    svgIcon={<MailSuccessIcon />}
-                    className={`mail-icon`}
-                  />
-                  Report mailed
-                </Button>
-              )}
-            </div>
-          )
-          }
           {showEditMailDetailsModal && (
             <EditMailDetailsModal
               showModal={showEditMailDetailsModal}

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -142,7 +142,7 @@ const ResultPage = ({ completedScanId: scanId }) => {
             <img alt="" src={boxArrowUpRightIcon}></img>
               View report
             </Button>
-            {isWindows && isEvent && ( 
+            {isWindows && isEvent && 
                 <>
                   {mailStatus === "send" && (
                   <Button

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -106,13 +106,13 @@ const ResultPage = ({ completedScanId: scanId }) => {
   const handleSubmitMail = async (finalEmails, finalSubject) => {
     setMailStatus("sending");
 
-    const emails = finalEmails.split(",").join(";");
-    const response = await services.mailReport(
-      { subject: finalSubject, emailAddresses: emails },
-      scanId
-    );
+    // const emails = finalEmails.split(",").join(";");
+    // const response = await services.mailReport(
+    //   { subject: finalSubject, emailAddresses: emails },
+    //   scanId
+    // );
     
-    if (response.success) {
+    if (true) {
       alert("Report successfully mailed");
       setMailStatus("sent");
 
@@ -142,8 +142,7 @@ const ResultPage = ({ completedScanId: scanId }) => {
             <img alt="" src={boxArrowUpRightIcon}></img>
               View report
             </Button>
-            {/* {isWindows && isEvent && ( */}
-            { true && 
+            {isWindows && isEvent && ( 
                 <>
                   {mailStatus === "send" && (
                   <Button

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -114,11 +114,7 @@ const ResultPage = ({ completedScanId: scanId }) => {
     
     if (response.success) {
       alert("Report successfully mailed");
-      setMailStatus("sent");
-
-      setTimeout(() => {
-        setMailStatus('send');
-      }, 1500);
+      setMailStatus("send");
     } else {
       alert("Report failed to mail");
       setMailStatus("send");
@@ -162,19 +158,6 @@ const ResultPage = ({ completedScanId: scanId }) => {
                     >
                       <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
                       Sending mail...
-                    </Button>
-                  )}
-                  {mailStatus === "sent" && (
-                    <Button
-                      id="mail-report-button"
-                      type="secondary"
-                      disabled="disabled"
-                    >
-                      <ButtonSvgIcon
-                        svgIcon={<MailSuccessIcon />}
-                        className={`mail-icon`}
-                      />
-                      Report mailed
                     </Button>
                   )}
               </>

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -7,10 +7,10 @@ import { handleClickLink } from "../../common/constants";
 import ButtonSvgIcon from "../../common/components/ButtonSvgIcon";
 import { ReactComponent as MailIcon } from "../../assets/mail.svg";
 import { ReactComponent as MailSuccessIcon } from "../../assets/mail-success.svg";
-import houseIcon from "../../assets/house.svg"; 
+import houseIcon from "../../assets/house.svg";
 import thumbsUpIcon from "../../assets/hand-thumbs-up.svg";
 import arrowRepeatIcon from "../../assets/arrow-repeat.svg";
-import checkCircleIcon from '../../assets/check-circle.svg'; 
+import checkCircleIcon from "../../assets/check-circle.svg";
 import boxArrowUpRightIcon from "../../assets/box-arrow-up-right.svg";
 import EditMailDetailsModal from "./EditMailDetailsModal";
 
@@ -21,17 +21,19 @@ const ResultPage = ({ completedScanId: scanId }) => {
   const [email, setEmail] = useState("");
   const [isEvent, setIsEvent] = useState(false);
   const [resultsPath, setResultsPath] = useState(null);
-  const [showCustomFlowReplayButton, setShowCustomFlowReplayButton] = useState(false);
-  const [customFlowLabel, setCustomFlowLabel] = useState('');
+  const [showCustomFlowReplayButton, setShowCustomFlowReplayButton] =
+    useState(false);
+  const [customFlowLabel, setCustomFlowLabel] = useState("");
   const [feedbackFormUrl, setFeedbackFormUrl] = useState(null);
   const [isWindows, setIsWindows] = useState(false);
   const [mailStatus, setMailStatus] = useState("send");
-  const [showEditMailDetailsModal, setShowEditMailDetailsModal] = useState(false);
-    
+  const [showEditMailDetailsModal, setShowEditMailDetailsModal] =
+    useState(false);
+
   useEffect(() => {
     if (state?.isCustomScan) {
       setShowCustomFlowReplayButton(state.isCustomScan);
-      setCustomFlowLabel(state.customFlowLabel)
+      setCustomFlowLabel(state.customFlowLabel);
     }
   }, []);
 
@@ -62,10 +64,10 @@ const ResultPage = ({ completedScanId: scanId }) => {
     const getFeedbackFormUrl = async () => {
       const feedbackFormUrl = await services.getFeedbackFormUrl();
       setFeedbackFormUrl(feedbackFormUrl);
-    }
+    };
 
     getFeedbackFormUrl();
-  }, [])
+  }, []);
 
   const initialSubject = useMemo(() => {
     if (!scanType) {
@@ -111,14 +113,13 @@ const ResultPage = ({ completedScanId: scanId }) => {
       { subject: finalSubject, emailAddresses: emails },
       scanId
     );
-    
+
     if (response.success) {
       alert("Report successfully mailed");
-      setMailStatus("send");
     } else {
       alert("Report failed to mail");
-      setMailStatus("send");
     }
+    setMailStatus("send");
   };
 
   return (
@@ -131,62 +132,74 @@ const ResultPage = ({ completedScanId: scanId }) => {
             You can find the downloaded report at{" "}
             <a href="#" onClick={handleOpenResultsFolder}>
               {resultsPath}
-            </a>.
+            </a>
+            .
           </p>
           <div id="btn-container">
             <Button id="view-button" type="primary" onClick={handleViewReport}>
-            <img alt="" src={boxArrowUpRightIcon}></img>
+              <img alt="" src={boxArrowUpRightIcon}></img>
               View report
             </Button>
-            {isWindows && isEvent && 
-                <>
-                  {mailStatus === "send" && (
+            {isWindows && isEvent && (
+              <>
+                {mailStatus === "send" && (
                   <Button
                     id="mail-report-button"
                     type="secondary"
                     onClick={() => setShowEditMailDetailsModal(true)}
                   >
-                    <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
+                    <ButtonSvgIcon
+                      svgIcon={<MailIcon />}
+                      className={`mail-icon`}
+                    />
                     Email report
                   </Button>
-                  )}
-                  {mailStatus === "sending" && (
-                    <Button
-                      id="mail-report-button"
-                      type="secondary"
-                      disabled="disabled"
-                    >
-                      <ButtonSvgIcon svgIcon={<MailIcon />} className={`mail-icon`} />
-                      Sending mail...
-                    </Button>
-                  )}
+                )}
+                {mailStatus === "sending" && (
+                  <Button
+                    id="mail-report-button"
+                    type="secondary"
+                    disabled="disabled"
+                  >
+                    <ButtonSvgIcon
+                      svgIcon={<MailIcon />}
+                      className={`mail-icon`}
+                    />
+                    Sending mail...
+                  </Button>
+                )}
               </>
-          }
+            )}
           </div>
-          <hr class="my-5"/>
+          <hr class="my-5" />
           <div id="other-actions">
             <h2>Other actions</h2>
             <ul class="actions-list">
               <li>
-                <a href="#" onClick={(e) => {handleClickLink(e, feedbackFormUrl)}}>
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    handleClickLink(e, feedbackFormUrl);
+                  }}
+                >
                   <img alt="" src={thumbsUpIcon}></img>
                   Help us improve
                 </a>
-              </li>     
-              { showCustomFlowReplayButton && 
+              </li>
+              {showCustomFlowReplayButton && (
                 <li>
                   <Link to="/custom_flow" state={{ isReplay: true }}>
                     <img alt="" src={arrowRepeatIcon}></img>
                     Rerun custom flow {`(${customFlowLabel})`}
                   </Link>
                 </li>
-              }
+              )}
               <li>
-                <hr/>
+                <hr />
                 <Link to="/" onClick={handleScanAgain}>
                   <img alt="" src={houseIcon}></img>
-                  Back To Home 
-                </Link>    
+                  Back To Home
+                </Link>
               </li>
             </ul>
           </div>

--- a/src/MainWindow/ResultPage/index.jsx
+++ b/src/MainWindow/ResultPage/index.jsx
@@ -106,13 +106,13 @@ const ResultPage = ({ completedScanId: scanId }) => {
   const handleSubmitMail = async (finalEmails, finalSubject) => {
     setMailStatus("sending");
 
-    // const emails = finalEmails.split(",").join(";");
-    // const response = await services.mailReport(
-    //   { subject: finalSubject, emailAddresses: emails },
-    //   scanId
-    // );
+    const emails = finalEmails.split(",").join(";");
+    const response = await services.mailReport(
+      { subject: finalSubject, emailAddresses: emails },
+      scanId
+    );
     
-    if (true) {
+    if (response.success) {
       alert("Report successfully mailed");
       setMailStatus("sent");
 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Improve the send email button on the Complete scan page
- Allow user to send more than once

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
