### PR TITLE
Modify element id used to get release notes info

### DIFF
--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -18,10 +18,10 @@ const WhatsNewModal = ({
 
     // remove unneeded info
     const allElements = releaseNotesNode.childNodes;
-    const toRemoveUpToId = "newfeatures";
+    const toRemoveUpToId = "whatsnew";
     for (const element of allElements) {
-      if (element.id === toRemoveUpToId) break;
       element.remove();
+      if (element.id === toRemoveUpToId) break;
     }
 
     const headings = releaseNotesNode.getElementsByTagName("h4");


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Removes info from release notes up to the Whats New section instead of New Features section
- Fixes bug where release notes are not displayed on version 0.9.33

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
