### PR TITLE
Fix GUI bug for basic auth, add option to follow robot.txt rules and minor changes to error page 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "purplea11ydesktop",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "purplea11ydesktop",
-      "version": "0.9.40",
+      "version": "0.9.41",
       "dependencies": {
         "axios": "^1.6.0",
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purplea11ydesktop",
   "productName": "Purple A11y",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "private": true,
   "dependencies": {
     "axios": "^1.6.0",

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -58,6 +58,7 @@ const getScanOptions = (details) => {
     falsePositive,
     includeScreenshots,
     includeSubdomains,
+    followRobots,
     metadata,
   } = details;
   const options = ["-c", scanType, "-u", url, "-k", `${name}:${email}`, "-i", fileTypes];
@@ -106,6 +107,10 @@ const getScanOptions = (details) => {
 
   if (falsePositive) {
     options.push("-f", "true");
+  }
+
+  if (followRobots) {
+    options.push("-r", "yes");
   }
 
   if (metadata) {

--- a/src/MainWindow/CustomFlow/index.jsx
+++ b/src/MainWindow/CustomFlow/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { cliErrorCodes, cliErrorTypes } from "../../common/constants";
+import { cliErrorCodes, cliErrorTypes, errorStates } from "../../common/constants";
 import services from "../../services";
 import './CustomFlow.scss';
 import arrowLeft from "../../assets/arrow-left-purple.svg";
@@ -195,7 +195,7 @@ const CustomFlowPage = ({ completedScanId, setCompletedScanId }) => {
           return;         
       }
 
-      navigate("/error", {state: { isCustomScan: true }});
+      navigate("/error", {state: { errorState: errorStates.customScanError }});
       return;
     } 
 

--- a/src/MainWindow/ErrorPage/ErrorPage.scss
+++ b/src/MainWindow/ErrorPage/ErrorPage.scss
@@ -28,4 +28,10 @@
     line-height: 1.5rem;
     background-color: transparent;
   }
+
+  .btn-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }

--- a/src/MainWindow/ErrorPage/index.jsx
+++ b/src/MainWindow/ErrorPage/index.jsx
@@ -55,21 +55,24 @@ const ErrorPage = () => {
         svgIcon={<ExclamationCircleIcon />}
       />
       {errorMessageToDisplay()}
+      <div class='btn-container'>
       {errorState === errorStates.customScanError
-      ? (
-        <>
-        <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>
-          <img src={returnIcon}></img>
-          &nbsp;Back To Home
-        </button>
-        <Button id="replay-btn" type="btn-primary" onClick={replayCustomFlow}>
-          Replay
-        </Button>
-        </>
-      )
-      : <Button role="link" type="btn-primary" onClick={handleBackToHome}>
-          Try Again
-        </Button>}
+        ? (
+          <>
+          <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>
+            <img src={returnIcon}></img>
+            &nbsp;Back To Home
+          </button>
+          <Button id="replay-btn" type="btn-primary" onClick={replayCustomFlow}>
+            Replay
+          </Button>
+          </>
+        )
+        : <Button role="link" type="btn-primary" onClick={handleBackToHome}>
+            Try Again
+          </Button>
+        }
+     </div>
     </div>
   );
 };

--- a/src/MainWindow/ErrorPage/index.jsx
+++ b/src/MainWindow/ErrorPage/index.jsx
@@ -5,21 +5,15 @@ import returnIcon from "../../assets/return-purple.svg";
 import { useNavigate, useLocation } from "react-router";
 import { ReactComponent as ExclamationCircleIcon } from "../../assets/exclamation-circle.svg";
 import { useState, useEffect } from "react";
+import { errorStates } from "../../common/constants";
 
 const ErrorPage = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  const [isCustomScan, setIsCustomScan] = useState(false);
-  const [isBrowserError, setIsBrowserError] = useState(false);
+  const [ errorState, setErrorState ] = useState('');
 
   useEffect(() => {
-    if (state?.isCustomScan) {
-      setIsCustomScan(state.isCustomScan);
-    }
-
-    if (state?.isBrowserError) {
-      setIsBrowserError(state.isBrowserError);
-    }
+    if (state?.errorState) setErrorState(state.errorState);
   }, []);
 
   const replayCustomFlow = async () => {
@@ -28,7 +22,7 @@ const ErrorPage = () => {
   };
 
   const handleBackToHome = () => {
-    if (isCustomScan) {
+    if (errorState === errorStates.customScanError) {
       window.services.cleanUpCustomFlowScripts();
       window.localStorage.removeItem("latestCustomFlowGeneratedScript");
       window.localStorage.removeItem("latestCustomFlowScanDetails");
@@ -37,20 +31,31 @@ const ErrorPage = () => {
     return;
   }
 
+  const errorMessageToDisplay = () => {
+    switch (errorState) {
+      case errorStates.browserError:
+        return (
+          <>
+            <h1>Unable to use browser to scan</h1>
+            <p>Please close either Google Chrome or Microsoft Edge browser.</p>
+          </>
+        )
+      case errorStates.noPagesScannedError:
+        return (<><h1>No pages were scanned.</h1></>)
+      default:
+        return (<><h1>Something went wrong! Please try again.</h1></>)
+    }
+
+  }
+
   return (
     <div id="error-page">
       <ButtonSvgIcon
         className={`exclamation-circle-icon`}
         svgIcon={<ExclamationCircleIcon />}
       />
-      {isBrowserError
-        ? <>
-            <h1>Unable to use browser to scan</h1>
-            <p>Please close either Google Chrome or Microsoft Edge browser.</p>
-          </>
-        : <h1>Something went wrong! Please try again.</h1>
-      }
-      {isCustomScan
+      {errorMessageToDisplay()}
+      {errorState === errorStates.customScanError
       ? (
         <>
         <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -226,42 +226,58 @@ const AdvancedScanOptions = ({
               </label>
           </div>
           {advancedOptions.scanType !== scanTypeOptions[3] && (
-            <div id="max-concurrency-toggle-group" class="advanced-options-toggle-group">
-              <input
-                type="checkbox"
-                id="max-concurrency-toggle"
-                class="advanced-options-toggle"
-                aria-describedby="max-concurrency-tooltip"
-                checked={advancedOptions.maxConcurrency}
-                onFocus={() => handleMaxConcurrencyOnFocus()}
-                onBlur={() => setShowMaxConcurrencyTooltip(false)}
-                onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
-                onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
-                onChange={handleSetAdvancedOption(
-                  "maxConcurrency",
-                  (e) => e.target.checked
-                )}
-              />
-
-              <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
-              <div className="custom-tooltip-container">
-                <ToolTip
-                  description={
-                    "Scan 1 page at a time instead of multiple pages concurrently."
-                  }
-                  id="max-concurrency-tooltip"
-                  showToolTip={showMaxConcurrencyTooltip}
-                />
-                <img
-                  className="tooltip-img"
-                  src={questionMarkIcon}
+            <>
+              <div id="max-concurrency-toggle-group" class="advanced-options-toggle-group">
+                <input
+                  type="checkbox"
+                  id="max-concurrency-toggle"
+                  class="advanced-options-toggle"
                   aria-describedby="max-concurrency-tooltip"
-                  onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
-                  onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
-                  alt="tooltip icon for slow scan mode"
+                  checked={advancedOptions.maxConcurrency}
+                  onFocus={() => handleMaxConcurrencyOnFocus()}
+                  onBlur={() => setShowMaxConcurrencyTooltip(false)}
+                  onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
+                  onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
+                  onChange={handleSetAdvancedOption(
+                    "maxConcurrency",
+                    (e) => e.target.checked
+                )}
                 />
+                <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
+                <div className="custom-tooltip-container">
+                  <ToolTip
+                    description={
+                      "Scan 1 page at a time instead of multiple pages concurrently."
+                    }
+                    id="max-concurrency-tooltip"
+                    showToolTip={showMaxConcurrencyTooltip}
+                  />
+                  <img
+                    className="tooltip-img"
+                    src={questionMarkIcon}
+                    aria-describedby="max-concurrency-tooltip"
+                    onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
+                    onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
+                    alt="tooltip icon for slow scan mode"
+                  />
+                </div>
               </div>
-            </div>
+              <div id='follow-robots-toggle-group' class="advanced-options-toggle-group">
+                  <input 
+                    type="checkbox"
+                    id="follow-robots-toggle" 
+                    class="advanced-options-toggle"
+                    checked={advancedOptions.followRobots}
+                    onChange={handleSetAdvancedOption(
+                      "followRobots", 
+                      (e) => e.target.checked
+                    )} 
+                  /> 
+                  <label htmlFor="follow-robots-toggle">
+                    Follow robots.txt rules
+                  </label>
+              </div>
+            </>
           )}
           <hr />
           <div className="user-input-group">

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -274,7 +274,7 @@ const AdvancedScanOptions = ({
                     )} 
                   /> 
                   <label htmlFor="follow-robots-toggle">
-                    Follow robots.txt rules
+                    Adhere to robots.txt
                   </label>
               </div>
             </>

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -164,7 +164,8 @@
 
   #false-positive-toggle-group,
   #screenshots-toggle-group,
-  #subdomain-toggle-group {
+  #subdomain-toggle-group,
+  #max-concurrency-toggle-group {
     margin-bottom: 1rem;
   }
 

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -250,6 +250,7 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
     const scanDetails = JSON.parse(window.localStorage.getItem("scanDetails"));
     const splitUrl = scanDetails.scanUrl.split("://");
     scanDetails.scanUrl = `${splitUrl[0]}://${username}:${password}@${splitUrl[1]}`;
+    setScanButtonIsClicked(true);
     startScan(scanDetails);
     setShowBasicAuthModal(false);
     return;

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -8,7 +8,7 @@ import labModeOn from "../../assets/lab-icon-on.svg";
 import InitScanForm from "./InitScanForm";
 import "./HomePage.scss";
 import services from "../../services";
-import { cliErrorCodes, cliErrorTypes, versionComparator } from "../../common/constants";
+import { cliErrorCodes, cliErrorTypes, errorStates, versionComparator } from "../../common/constants";
 import Modal from "../../common/components/Modal";
 import { BasicAuthForm, BasicAuthFormFooter } from "./BasicAuthForm";
 import EditUserDetailsModal from "./EditUserDetailsModal";
@@ -195,7 +195,7 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
           } else {
             /* When no pages were scanned (e.g. out of domain upon redirects when valid URL was entered),
                 redirects user to error page to going to result page with empty result */
-            navigate("/error");
+            navigate("/error", { state: { errorState: errorStates.noPagesScannedError }});
             return; 
           }   
         }
@@ -223,7 +223,7 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
             errorMessageToShow = "Invalid sitemap.";
             break;
           case cliErrorTypes.browserError:
-            navigate('/error', { state: { isBrowserError: true }});
+            navigate('/error', { state: { errorState: errorStates.browserError }});
             return;
           case cliErrorTypes.systemError:
           default:

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -104,6 +104,12 @@ export const cliErrorTypes = {
   browserError: 17,
 };
 
+export const errorStates = {
+  browserError: 'browserError',
+  customScanError: 'customScanError', 
+  noPagesScannedError: 'noPagesScannedError'
+}
+
 export const userDataFormDetails = {
   // production form
   // formUrl: "https://form.gov.sg/6453387735eb0c00128becdc",

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -88,7 +88,8 @@ export const getDefaultAdvancedOptions = (isProxy) => {
     maxConcurrency: false, 
     falsePositive: false,
     includeScreenshots: true,
-    includeSubdomains: true
+    includeSubdomains: true,
+    followRobots: false,
   }
 };
 

--- a/src/services.js
+++ b/src/services.js
@@ -68,6 +68,7 @@ const startScan = async (scanDetails) => {
     falsePositive,
     includeScreenshots,
     includeSubdomains,
+    followRobots,
     scanMetadata,
   } = scanDetails;
 
@@ -85,6 +86,7 @@ const startScan = async (scanDetails) => {
     fileTypes: fileTypes[selectedFileTypes],
     includeScreenshots,
     includeSubdomains,
+    followRobots,
     metadata: JSON.stringify(scanMetadata),
   };
 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Set loading state for scan form components after users enter credentials for basic auth 
- Add checkbox for users to follow robots.txt rules 
- Display more specific error message when there is no pages scanned
- Fix button placement on error page 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
