### PR TITLE
Fix uncentered buttons on error page

### DIFF
--- a/src/MainWindow/ErrorPage/ErrorPage.scss
+++ b/src/MainWindow/ErrorPage/ErrorPage.scss
@@ -28,4 +28,9 @@
     line-height: 1.5rem;
     background-color: transparent;
   }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/src/MainWindow/ErrorPage/index.jsx
+++ b/src/MainWindow/ErrorPage/index.jsx
@@ -50,21 +50,23 @@ const ErrorPage = () => {
           </>
         : <h1>Something went wrong! Please try again.</h1>
       }
-      {isCustomScan
-      ? (
-        <>
-        <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>
-          <img src={returnIcon}></img>
-          &nbsp;Back To Home
-        </button>
-        <Button id="replay-btn" type="btn-primary" onClick={replayCustomFlow}>
-          Replay
-        </Button>
-        </>
-      )
-      : <Button role="link" type="btn-primary" onClick={handleBackToHome}>
-          Try Again
-        </Button>}
+      <div class="actions">
+        {isCustomScan
+        ? (
+          <>
+          <button role="link" id='back-to-home-btn' onClick={handleBackToHome}>
+            <img src={returnIcon}></img>
+            &nbsp;Back To Home
+          </button>
+          <Button id="replay-btn" type="btn-primary" onClick={replayCustomFlow}>
+            Replay
+          </Button>
+          </>
+        )
+        : <Button role="link" type="btn-primary" onClick={handleBackToHome}>
+            Try Again
+          </Button>}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Fix uncentered buttons on error page due to change in `btn-primary` class styling

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
