### PR TITLE
fixed updater to support dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": ".",
   "scripts": {
     "dev": "react-scripts start",
-    "start": "electron-forge start",
+    "start": "NODE_ENV=dev electron-forge start",
     "build": "react-scripts build",
     "test:update-screenshot": "npx playwright test --update-snapshots",
     "eject": "react-scripts eject",

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -387,7 +387,12 @@ const run = async (updaterEventEmitter, latestRelease, latestPreRelease) => {
     }
 
     const isPrepackageValid = await validateZipFile(macOSPrepackageBackend);
-    if (isPrepackageValid) {
+    const isDev = process.env.NODE_ENV === "dev";
+    if (isDev) {
+      consoleLogger.info(
+        "detected running from dev environment, will not validate/download prepackage"
+      );
+    } else if (isPrepackageValid) {
       let skipUnzip = false;
       if (getBackendExists() && fs.existsSync(hashPath)) {
         consoleLogger.info("backend and hash path exists");


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Add support for updater in development environment

Previously prepackage will not be present and attempt to download backend portable will fail as resources folder not present in development env. Current fix is to detect when in dev env and skip check for prepackage. Updater will now assume backend in development environment is setup properly.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
