### PR TITLE
Initialise date object for timeOfScan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purplea11ydesktop",
   "productName": "Purple A11y",
-  "version": "0.9.51",
+  "version": "0.9.52",
   "private": true,
   "dependencies": {
     "axios": "^1.6.0",

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -646,7 +646,7 @@ const init = (scanEvent) => {
     return uploadFolderPath;
   })
 
-  ipcMain.handle("getErrorLog", async (event, timeOfScan, timeOfError) => {
+  ipcMain.handle("getErrorLog", async (event, timeOfScanString, timeOfError) => {
       const errorLogPath = path.join(appPath, 'errors.txt');
       const errorLog = fs.readFileSync(errorLogPath, 'utf-8');  
       const regex = /{.*?}/gs; 
@@ -674,6 +674,7 @@ const init = (scanEvent) => {
       for (const entry of entries){
         const jsonEntry = JSON.parse(entry);
         const timeOfEntry = new Date(jsonEntry['timestamp']).getTime(); 
+        const timeOfScan = new Date(timeOfScanString);
         if (timeOfEntry >= timeOfScan.getTime() && timeOfEntry <= timeOfError.getTime()){
           allErrors = allErrors.concat(entry,"\n")
         }


### PR DESCRIPTION
 - Fix for custom scan mode

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
