### PR TITLE
Changing LocalFileScan from a scan mode to input scan type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24919,9 +24919,10 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.14.2",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -25646,9 +25647,10 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.9",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -202,14 +202,9 @@ app.on("ready", async () => {
 
   ipcMain.handle("isWindows", (_event) => constants.isWindows);
 
-  ipcMain.handle('selectFile', async () => {
-    const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ['openFile'],
-      filters: [
-        { name: 'Supported files', extensions: ['dhtml','html','htm','txt','shtml','xml', 'xhtml'] },
-        { name: 'All Files', extensions: ['*'] }
-      ]
-    });
+  ipcMain.handle('selectFile', async (event, options = {}) => {
+
+    const result = await dialog.showOpenDialog(mainWindow, options);
   
     if (!result.canceled && result.filePaths.length > 0) {
       return result.filePaths[0];

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -15,11 +15,14 @@ contextBridge.exposeInMainWorld("services", {
     ipcRenderer.send("restartApp");
   },
   checkChromeExistsOnMac: async () => {
-    const chromeExists = await ipcRenderer.invoke("checkChromeExistsOnMac"); 
+    const chromeExists = await ipcRenderer.invoke("checkChromeExistsOnMac");
     return chromeExists;
   },
   validateUrlConnectivity: async (scanDetails) => {
-    const results = await ipcRenderer.invoke('validateUrlConnectivity', scanDetails);
+    const results = await ipcRenderer.invoke(
+      "validateUrlConnectivity",
+      scanDetails
+    );
     return results;
   },
   startScan: async (scanDetails) => {
@@ -43,7 +46,7 @@ contextBridge.exposeInMainWorld("services", {
     ipcRenderer.send("openUploadFolder");
   },
   getEngineVersion: async () => {
-    const phEngineVersion = await ipcRenderer.invoke('getEngineVersion'); 
+    const phEngineVersion = await ipcRenderer.invoke("getEngineVersion");
     return phEngineVersion;
   },
   getResultsFolderPath: async (scanId) => {
@@ -63,7 +66,11 @@ contextBridge.exposeInMainWorld("services", {
     return data;
   },
   getErrorLog: async (timeOfScan, timeOfError) => {
-    const errorLog = await ipcRenderer.invoke("getErrorLog", timeOfScan, timeOfError);
+    const errorLog = await ipcRenderer.invoke(
+      "getErrorLog",
+      timeOfScan,
+      timeOfError
+    );
     return errorLog;
   },
   editUserData: async (userData) => {
@@ -85,7 +92,7 @@ contextBridge.exposeInMainWorld("services", {
   scanningUrl: (callback) => {
     ipcRenderer.on("scanningUrl", (event, data) => {
       callback(data);
-    })
+    });
   },
   scanningCompleted: (callback) => {
     ipcRenderer.on("scanningCompleted", () => {
@@ -95,7 +102,7 @@ contextBridge.exposeInMainWorld("services", {
   killScan: (callback) => {
     ipcRenderer.on("killScan", () => {
       callback();
-    })
+    });
   },
   userDataExists: (callback) => {
     ipcRenderer.on("userDataExists", (event, data) => {
@@ -128,9 +135,9 @@ contextBridge.exposeInMainWorld("services", {
     );
     return response;
   },
-  selectFile: async () => {
-    const filePath = await ipcRenderer.invoke('selectFile');
-    return filePath;
-  },
-  getIsWindows: async () => ipcRenderer.invoke("isWindows"),
-});
+    selectFile: async (options) => {
+      const filePath = await ipcRenderer.invoke("selectFile", options);
+      return filePath;
+    },
+    getIsWindows: async () => ipcRenderer.invoke("isWindows"),
+  });

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -20,7 +20,7 @@ const AdvancedScanOptions = ({
   advancedOptions,
   setAdvancedOptions,
   scanButtonIsClicked,
-  isCustomOptionChecked,
+  isFileOptionChecked,
 }) => {
   const [openAdvancedOptionsMenu, setOpenAdvancedOptionsMenu] = useState(false);
   const [advancedOptionsDirty, setAdvancedOptionsDirty] = useState(false);
@@ -207,7 +207,7 @@ const AdvancedScanOptions = ({
             />
             <label htmlFor="screenshots-toggle">Include screenshots</label>
           </div>
-          {!isCustomOptionChecked && advancedOptions.scanType === scanTypeOptions[0] && 
+          {!isFileOptionChecked && advancedOptions.scanType === scanTypeOptions[0] && 
             <div id='subdomain-toggle-group' class="advanced-options-toggle-group">
               <input 
                 type="checkbox"

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -136,7 +136,7 @@ const AdvancedScanOptions = ({
             id="scan-type-dropdown"
             label="Scan Type:"
             initialValue={advancedOptions.scanType}
-            options={scanTypeOptions}
+            options={scanTypeOptions.filter((_, index) => index !== 3)}
             onChange={handleSetAdvancedOption("scanType")}
           />
           <SelectField

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -20,12 +20,12 @@ const AdvancedScanOptions = ({
   advancedOptions,
   setAdvancedOptions,
   scanButtonIsClicked,
-  isCustomOptionChecked
+  isCustomOptionChecked,
 }) => {
   const [openAdvancedOptionsMenu, setOpenAdvancedOptionsMenu] = useState(false);
   const [advancedOptionsDirty, setAdvancedOptionsDirty] = useState(false);
   const [isMaxConcurrencyMouseEvent, setIsMaxConcurrencyMouseEvent] = useState(false);
-  const [showMaxConcurrencyTooltip, setShowMaxConcurrencyTooltip] = useState(false);
+  const [showMaxConcurrencyTooltip, setShowMaxConcurrencyTooltip] =  useState(false);
   const [isSafeModeMouseEvent, setIsSafeModeMouseEvent] = useState(false);
   const [showSafeModeTooltip, setShowSafeModeTooltip] = useState(false);
 
@@ -62,6 +62,7 @@ const AdvancedScanOptions = ({
     setIsMaxConcurrencyMouseEvent(true);
   };
 
+  
   const handleSafeModeOnFocus = () => {
     if (!isSafeModeMouseEvent) {
       setShowSafeModeTooltip(true);
@@ -69,34 +70,44 @@ const AdvancedScanOptions = ({
   };
 
   const handleSafeModeOnMouseEnter = () => {
-    setShowSafeModeTooltip(false);
-    setIsSafeModeMouseEvent(true);
+      setShowSafeModeTooltip(false);
+      setIsSafeModeMouseEvent(true);
   };
 
-  const handleSetAdvancedOption = (option, overrideVal = null) => (event) => {
-    let val;
-    if (overrideVal) {
-      val = overrideVal(event);
-    } else {
-      val = event.target.value;
-    }
 
-    const newOptions = { ...advancedOptions };
-    newOptions[option] = val;
-    setAdvancedOptions(newOptions);
 
-    const defaultAdvancedOptions = getDefaultAdvancedOptions(isProxy);
-    const isNewOptionsDefault = Object.keys(defaultAdvancedOptions).reduce(
-      (isDefaultSoFar, key) => {
-        return (
-          isDefaultSoFar && defaultAdvancedOptions[key] === newOptions[key]
-        );
-      },
-      true
-    );
+  /*
+  by default, new value of the selected option will be set to event.target.value
+  if the new value should be something else, provide a function to overrideVal that returns
+  the intended value. Function should be in the format (event) => {...; return valueToBeReturned;}
+  */
+  const handleSetAdvancedOption =
+    (option, overrideVal = null) =>
+    (event) => {
+      let val;
+      if (overrideVal) {
+        val = overrideVal(event);
+      } else {
+        val = event.target.value;
+      }
 
-    setAdvancedOptionsDirty(!isNewOptionsDefault);
-  };
+      const newOptions = { ...advancedOptions };
+      newOptions[option] = val;
+      setAdvancedOptions(newOptions);
+
+      // check if new options are the default
+      const defaultAdvancedOptions = getDefaultAdvancedOptions(isProxy);
+      const isNewOptionsDefault = Object.keys(defaultAdvancedOptions).reduce(
+        (isDefaultSoFar, key) => {
+          return (
+            isDefaultSoFar && defaultAdvancedOptions[key] === newOptions[key]
+          );
+        },
+        true
+      );
+
+      setAdvancedOptionsDirty(!isNewOptionsDefault);
+    };
 
   return (
     <div>
@@ -136,15 +147,16 @@ const AdvancedScanOptions = ({
             options={Object.values(viewportOptions)}
             onChange={handleSetAdvancedOption("viewport")}
           />
-          {advancedOptions.viewport === viewportOptions.specific && !isProxy && (
-            <SelectField
-              id="specific-device-dropdown"
-              label="Device:"
-              initialValue={advancedOptions.device}
-              options={deviceOptions}
-              onChange={handleSetAdvancedOption("device")}
-            />
-          )}
+          {advancedOptions.viewport === viewportOptions.specific &&
+            !isProxy && (
+              <SelectField
+                id="specific-device-dropdown"
+                label="Device:"
+                initialValue={advancedOptions.device}
+                options={deviceOptions}
+                onChange={handleSetAdvancedOption("device")}
+              />
+            )}
           {advancedOptions.viewport === viewportOptions.custom && (
             <div className="user-input-group">
               <label htmlFor="viewport-width-input" className="bold-text">
@@ -173,20 +185,34 @@ const AdvancedScanOptions = ({
             </div>
           )}
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-            <SelectField
-              id="file-type-dropdown"
-              label="File Type:"
-              initialValue={advancedOptions.fileTypes}
-              options={fileTypesOptions}
-              onChange={handleSetAdvancedOption("fileTypes")}
+              <SelectField
+                id="file-type-dropdown"
+                label="File Type:"
+                initialValue={advancedOptions.fileTypes}
+                options={fileTypesOptions}
+                onChange={handleSetAdvancedOption("fileTypes")}
+              />
+            )}
+          <div id="screenshots-toggle-group" class="advanced-options-toggle-group">
+            <input
+              type="checkbox"
+              id="screenshots-toggle"
+              class="advanced-options-toggle"
+              aria-describedby="screenshots-tooltip"
+              checked={advancedOptions.includeScreenshots}
+              onChange={handleSetAdvancedOption(
+                "includeScreenshots",
+                (e) => e.target.checked
+              )}
             />
-          )}
-          {!isCustomOptionChecked && advancedOptions.scanType === scanTypeOptions[0] && (
-            <div id='subdomain-toggle-group' className="advanced-options-toggle-group">
+            <label htmlFor="screenshots-toggle">Include screenshots</label>
+          </div>
+          {!isCustomOptionChecked && advancedOptions.scanType === scanTypeOptions[0] && 
+            <div id='subdomain-toggle-group' class="advanced-options-toggle-group">
               <input 
                 type="checkbox"
                 id="subdomain-toggle"
-                className="advanced-options-toggle"
+                class="advanced-options-toggle"
                 checked={advancedOptions.includeSubdomains}
                 onChange={handleSetAdvancedOption(
                   "includeSubdomains", 
@@ -197,120 +223,106 @@ const AdvancedScanOptions = ({
                 Allow subdomains for scans
               </label>
             </div>
-          )}
-          <div id="screenshots-toggle-group" className="advanced-options-toggle-group">
-            <input
-              type="checkbox"
-              id="screenshots-toggle"
-              className="advanced-options-toggle"
-              aria-describedby="screenshots-tooltip"
-              checked={advancedOptions.includeScreenshots}
-              onChange={handleSetAdvancedOption(
-                "includeScreenshots",
-                (e) => e.target.checked
-              )}
-            />
-            <label htmlFor="screenshots-toggle">Include screenshots</label>
-          </div>
+          }
+
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-          <div id="max-concurrency-toggle-group" className="advanced-options-toggle-group">
-            <input
-              type="checkbox"
-              id="max-concurrency-toggle"
-              className="advanced-options-toggle"
-              aria-describedby="max-concurrency-tooltip"
-              checked={advancedOptions.maxConcurrency}
-              onFocus={() => handleMaxConcurrencyOnFocus()}
-              onBlur={() => setShowMaxConcurrencyTooltip(false)}
-              onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
-              onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
-              onChange={handleSetAdvancedOption(
-                "maxConcurrency",
-                (e) => e.target.checked
-              )}
-            />
-            <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
-            <div className="custom-tooltip-container">
-              <ToolTip
-                description={
-                  "Scan 1 page at a time instead of multiple pages concurrently."
-                }
-                id="max-concurrency-tooltip"
-                showToolTip={showMaxConcurrencyTooltip}
-              />
-              <img
-                className="tooltip-img"
-                src={questionMarkIcon}
-                aria-describedby="max-concurrency-tooltip"
-                checked={advancedOptions.maxConcurrency}
-                onFocus={() => handleMaxConcurrencyOnFocus()}
-                onBlur={() => setShowMaxConcurrencyTooltip(false)}
-                onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
-                onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
-                alt="tooltip icon for slow scan mode"
-              />
-            </div>
-          </div>
-          )}
-          {advancedOptions.scanType !== scanTypeOptions[2] && (
-          <div id='safe-mode-toggle-group' className="advanced-options-toggle-group">
-            <input 
-              type="checkbox"
-              id="safe-mode-toggle" 
-              className="advanced-options-toggle"
-              onFocus={() => handleSafeModeOnFocus()}
-              onBlur={() => setShowSafeModeTooltip(false)}
-              onMouseEnter={() => handleSafeModeOnMouseEnter()}
-              onMouseLeave={() => setIsSafeModeMouseEvent(false)}
-              aria-describedby="safe-mode-tooltip"
-              checked={advancedOptions.safeMode}
-              onChange={handleSetAdvancedOption(
-                "safeMode", 
-                (e) => e.target.checked
-              )} 
-            /> 
-            <label htmlFor="safe-mode-toggle">
-              Safe Scan Mode 
-            </label>
-            <div className="custom-tooltip-container">
-              <ToolTip
-                description={
-                  "Disable dynamically clicking of page buttons and links to find links, which resolve issues on some websites."
-                }
-                id="safe-mode-tooltip"
-                showToolTip={showSafeModeTooltip}
-              />
-              <img
-                className="tooltip-img"
-                src={questionMarkIcon}
-                checked={advancedOptions.safeMode}
-                aria-describedby="safe-mode-tooltip"
-                onFocus={() => handleSafeModeOnFocus()}
-                onBlur={() => setShowSafeModeTooltip(false)}
-                onMouseEnter={() => setShowSafeModeTooltip(true)}
-                onMouseLeave={() => setShowSafeModeTooltip(false)}
-                alt="tooltip icon for safe scan mode"
-              />
-            </div>
-          </div>
-          )}
-          {advancedOptions.scanType !== scanTypeOptions[2] && (
-          <div id='follow-robots-toggle-group' className="advanced-options-toggle-group">
-            <input 
-              type="checkbox"
-              id="follow-robots-toggle" 
-              className="advanced-options-toggle"
-              aria-describedby="follow-robots-tooltip"
-              checked={advancedOptions.followRobots}
-              onChange={handleSetAdvancedOption(
-                "followRobots", 
-                (e) => e.target.checked
-              )} 
-            /> 
-            <label htmlFor="follow-robots-toggle">
-              Adhere to robots.txt
-            </label>
-          </div>
+            <>
+              <div id="max-concurrency-toggle-group" class="advanced-options-toggle-group">
+                <input
+                  type="checkbox"
+                  id="max-concurrency-toggle"
+                  class="advanced-options-toggle"
+                  aria-describedby="max-concurrency-tooltip"
+                  checked={advancedOptions.maxConcurrency}
+                  onFocus={() => handleMaxConcurrencyOnFocus()}
+                  onBlur={() => setShowMaxConcurrencyTooltip(false)}
+                  onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
+                  onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
+                  onChange={handleSetAdvancedOption(
+                    "maxConcurrency",
+                    (e) => e.target.checked
+                )}
+                />
+                <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
+                <div className="custom-tooltip-container">
+                  <ToolTip
+                    description={
+                      "Scan 1 page at a time instead of multiple pages concurrently."
+                    }
+                    id="max-concurrency-tooltip"
+                    showToolTip={showMaxConcurrencyTooltip}
+                  />
+                  <img
+                    className="tooltip-img"
+                    src={questionMarkIcon}
+                    aria-describedby="max-concurrency-tooltip"
+                    checked={advancedOptions.maxConcurrency}
+                    onFocus={() => handleMaxConcurrencyOnFocus()}
+                    onBlur={() => setShowMaxConcurrencyTooltip(false)}
+                    onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
+                    onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
+                    alt="tooltip icon for slow scan mode"
+                  />
+                </div>
+              </div>
+              <div id='safe-mode-toggle-group' class="advanced-options-toggle-group">
+                  <input 
+                    type="checkbox"
+                    id="safe-mode-toggle" 
+                    class="advanced-options-toggle"
+                    onFocus={() => handleSafeModeOnFocus()}
+                    onBlur={() => setShowSafeModeTooltip(false)}
+                    onMouseEnter={() => handleSafeModeOnMouseEnter()}
+                    onMouseLeave={() => setIsSafeModeMouseEvent(false)}
+                    aria-describedby="safe-mode-tooltip"
+                    checked={advancedOptions.safeMode}
+                    onChange={handleSetAdvancedOption(
+                      "safeMode", 
+                      (e) => e.target.checked
+                    )} 
+                  /> 
+                  <label htmlFor="safe-mode-toggle">
+                    Safe Scan Mode 
+                  </label>
+                  <div className="custom-tooltip-container">
+                  <ToolTip
+                    description={
+                      "Disable dynamically clicking of page buttons and links to find links, which resolve issues on some websites."
+                    }
+                    id="safe-mode-tooltip"
+                    showToolTip={showSafeModeTooltip}
+                  />
+                  <img
+                    className="tooltip-img"
+                    src={questionMarkIcon}
+                    checked={advancedOptions.safeMode}
+                    aria-describedby="safe-mode-tooltip"
+                    onFocus={() => handleSafeModeOnFocus()}
+                    onBlur={() => setShowSafeModeTooltip(false)}
+                    onMouseEnter={() => setShowSafeModeTooltip(true)}
+                    onMouseLeave={() => setShowSafeModeTooltip(false)}
+                    alt="tooltip icon for safe scan mode"
+                  />
+                </div>
+              </div>
+              <div id='follow-robots-toggle-group' class="advanced-options-toggle-group">
+                  <input 
+                    type="checkbox"
+                    id="follow-robots-toggle" 
+                    class="advanced-options-toggle"
+                    
+                    aria-describedby="follow-robots-tooltip"
+                    checked={advancedOptions.followRobots}
+                    onChange={handleSetAdvancedOption(
+                      "followRobots", 
+                      (e) => e.target.checked
+                    )} 
+                  /> 
+                  <label htmlFor="follow-robots-toggle">
+                    Adhere to robots.txt
+                  </label>
+              </div>
+            </>
           )}
           <hr />
           <div className="user-input-group">
@@ -319,6 +331,20 @@ const AdvancedScanOptions = ({
             </label>
             <DownloadFolderDropdown></DownloadFolderDropdown>
           </div>
+          {/* <div id="scan-in-background-toggle-group">
+            <input
+              type="checkbox"
+              id="scan-in-background-toggle"
+              checked={advancedOptions.scanInBackground}
+              onChange={handleSetAdvancedOption(
+                "scanInBackground",
+                (e) => e.target.checked
+              )}
+            />
+            <label htmlFor="scan-in-background-toggle">
+              Scan in background
+            </label>
+          </div> */}
         </div>
       )}
     </div>

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -19,12 +19,13 @@ const AdvancedScanOptions = ({
   deviceOptions,
   advancedOptions,
   setAdvancedOptions,
-  scanButtonIsClicked
+  scanButtonIsClicked,
+  isCustomOptionChecked
 }) => {
   const [openAdvancedOptionsMenu, setOpenAdvancedOptionsMenu] = useState(false);
   const [advancedOptionsDirty, setAdvancedOptionsDirty] = useState(false);
   const [isMaxConcurrencyMouseEvent, setIsMaxConcurrencyMouseEvent] = useState(false);
-  const [showMaxConcurrencyTooltip, setShowMaxConcurrencyTooltip] =  useState(false);
+  const [showMaxConcurrencyTooltip, setShowMaxConcurrencyTooltip] = useState(false);
   const [isSafeModeMouseEvent, setIsSafeModeMouseEvent] = useState(false);
   const [showSafeModeTooltip, setShowSafeModeTooltip] = useState(false);
 
@@ -61,7 +62,6 @@ const AdvancedScanOptions = ({
     setIsMaxConcurrencyMouseEvent(true);
   };
 
-  
   const handleSafeModeOnFocus = () => {
     if (!isSafeModeMouseEvent) {
       setShowSafeModeTooltip(true);
@@ -69,44 +69,34 @@ const AdvancedScanOptions = ({
   };
 
   const handleSafeModeOnMouseEnter = () => {
-      setShowSafeModeTooltip(false);
-      setIsSafeModeMouseEvent(true);
+    setShowSafeModeTooltip(false);
+    setIsSafeModeMouseEvent(true);
   };
 
+  const handleSetAdvancedOption = (option, overrideVal = null) => (event) => {
+    let val;
+    if (overrideVal) {
+      val = overrideVal(event);
+    } else {
+      val = event.target.value;
+    }
 
+    const newOptions = { ...advancedOptions };
+    newOptions[option] = val;
+    setAdvancedOptions(newOptions);
 
-  /*
-  by default, new value of the selected option will be set to event.target.value
-  if the new value should be something else, provide a function to overrideVal that returns
-  the intended value. Function should be in the format (event) => {...; return valueToBeReturned;}
-  */
-  const handleSetAdvancedOption =
-    (option, overrideVal = null) =>
-    (event) => {
-      let val;
-      if (overrideVal) {
-        val = overrideVal(event);
-      } else {
-        val = event.target.value;
-      }
+    const defaultAdvancedOptions = getDefaultAdvancedOptions(isProxy);
+    const isNewOptionsDefault = Object.keys(defaultAdvancedOptions).reduce(
+      (isDefaultSoFar, key) => {
+        return (
+          isDefaultSoFar && defaultAdvancedOptions[key] === newOptions[key]
+        );
+      },
+      true
+    );
 
-      const newOptions = { ...advancedOptions };
-      newOptions[option] = val;
-      setAdvancedOptions(newOptions);
-
-      // check if new options are the default
-      const defaultAdvancedOptions = getDefaultAdvancedOptions(isProxy);
-      const isNewOptionsDefault = Object.keys(defaultAdvancedOptions).reduce(
-        (isDefaultSoFar, key) => {
-          return (
-            isDefaultSoFar && defaultAdvancedOptions[key] === newOptions[key]
-          );
-        },
-        true
-      );
-
-      setAdvancedOptionsDirty(!isNewOptionsDefault);
-    };
+    setAdvancedOptionsDirty(!isNewOptionsDefault);
+  };
 
   return (
     <div>
@@ -136,7 +126,7 @@ const AdvancedScanOptions = ({
             id="scan-type-dropdown"
             label="Scan Type:"
             initialValue={advancedOptions.scanType}
-            options={scanTypeOptions.filter((_, index) => index !== 3)}
+            options={scanTypeOptions}
             onChange={handleSetAdvancedOption("scanType")}
           />
           <SelectField
@@ -146,16 +136,15 @@ const AdvancedScanOptions = ({
             options={Object.values(viewportOptions)}
             onChange={handleSetAdvancedOption("viewport")}
           />
-          {advancedOptions.viewport === viewportOptions.specific &&
-            !isProxy && (
-              <SelectField
-                id="specific-device-dropdown"
-                label="Device:"
-                initialValue={advancedOptions.device}
-                options={deviceOptions}
-                onChange={handleSetAdvancedOption("device")}
-              />
-            )}
+          {advancedOptions.viewport === viewportOptions.specific && !isProxy && (
+            <SelectField
+              id="specific-device-dropdown"
+              label="Device:"
+              initialValue={advancedOptions.device}
+              options={deviceOptions}
+              onChange={handleSetAdvancedOption("device")}
+            />
+          )}
           {advancedOptions.viewport === viewportOptions.custom && (
             <div className="user-input-group">
               <label htmlFor="viewport-width-input" className="bold-text">
@@ -184,34 +173,20 @@ const AdvancedScanOptions = ({
             </div>
           )}
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-              <SelectField
-                id="file-type-dropdown"
-                label="File Type:"
-                initialValue={advancedOptions.fileTypes}
-                options={fileTypesOptions}
-                onChange={handleSetAdvancedOption("fileTypes")}
-              />
-            )}
-          <div id="screenshots-toggle-group" class="advanced-options-toggle-group">
-            <input
-              type="checkbox"
-              id="screenshots-toggle"
-              class="advanced-options-toggle"
-              aria-describedby="screenshots-tooltip"
-              checked={advancedOptions.includeScreenshots}
-              onChange={handleSetAdvancedOption(
-                "includeScreenshots",
-                (e) => e.target.checked
-              )}
+            <SelectField
+              id="file-type-dropdown"
+              label="File Type:"
+              initialValue={advancedOptions.fileTypes}
+              options={fileTypesOptions}
+              onChange={handleSetAdvancedOption("fileTypes")}
             />
-            <label htmlFor="screenshots-toggle">Include screenshots</label>
-          </div>
-          { advancedOptions.scanType === scanTypeOptions[0] && 
-            <div id='subdomain-toggle-group' class="advanced-options-toggle-group">
+          )}
+          {!isCustomOptionChecked && advancedOptions.scanType === scanTypeOptions[0] && (
+            <div id='subdomain-toggle-group' className="advanced-options-toggle-group">
               <input 
                 type="checkbox"
                 id="subdomain-toggle"
-                class="advanced-options-toggle"
+                className="advanced-options-toggle"
                 checked={advancedOptions.includeSubdomains}
                 onChange={handleSetAdvancedOption(
                   "includeSubdomains", 
@@ -222,106 +197,120 @@ const AdvancedScanOptions = ({
                 Allow subdomains for scans
               </label>
             </div>
-          }
-
+          )}
+          <div id="screenshots-toggle-group" className="advanced-options-toggle-group">
+            <input
+              type="checkbox"
+              id="screenshots-toggle"
+              className="advanced-options-toggle"
+              aria-describedby="screenshots-tooltip"
+              checked={advancedOptions.includeScreenshots}
+              onChange={handleSetAdvancedOption(
+                "includeScreenshots",
+                (e) => e.target.checked
+              )}
+            />
+            <label htmlFor="screenshots-toggle">Include screenshots</label>
+          </div>
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-            <>
-              <div id="max-concurrency-toggle-group" class="advanced-options-toggle-group">
-                <input
-                  type="checkbox"
-                  id="max-concurrency-toggle"
-                  class="advanced-options-toggle"
-                  aria-describedby="max-concurrency-tooltip"
-                  checked={advancedOptions.maxConcurrency}
-                  onFocus={() => handleMaxConcurrencyOnFocus()}
-                  onBlur={() => setShowMaxConcurrencyTooltip(false)}
-                  onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
-                  onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
-                  onChange={handleSetAdvancedOption(
-                    "maxConcurrency",
-                    (e) => e.target.checked
-                )}
-                />
-                <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
-                <div className="custom-tooltip-container">
-                  <ToolTip
-                    description={
-                      "Scan 1 page at a time instead of multiple pages concurrently."
-                    }
-                    id="max-concurrency-tooltip"
-                    showToolTip={showMaxConcurrencyTooltip}
-                  />
-                  <img
-                    className="tooltip-img"
-                    src={questionMarkIcon}
-                    aria-describedby="max-concurrency-tooltip"
-                    checked={advancedOptions.maxConcurrency}
-                    onFocus={() => handleMaxConcurrencyOnFocus()}
-                    onBlur={() => setShowMaxConcurrencyTooltip(false)}
-                    onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
-                    onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
-                    alt="tooltip icon for slow scan mode"
-                  />
-                </div>
-              </div>
-              <div id='safe-mode-toggle-group' class="advanced-options-toggle-group">
-                  <input 
-                    type="checkbox"
-                    id="safe-mode-toggle" 
-                    class="advanced-options-toggle"
-                    onFocus={() => handleSafeModeOnFocus()}
-                    onBlur={() => setShowSafeModeTooltip(false)}
-                    onMouseEnter={() => handleSafeModeOnMouseEnter()}
-                    onMouseLeave={() => setIsSafeModeMouseEvent(false)}
-                    aria-describedby="safe-mode-tooltip"
-                    checked={advancedOptions.safeMode}
-                    onChange={handleSetAdvancedOption(
-                      "safeMode", 
-                      (e) => e.target.checked
-                    )} 
-                  /> 
-                  <label htmlFor="safe-mode-toggle">
-                    Safe Scan Mode 
-                  </label>
-                  <div className="custom-tooltip-container">
-                  <ToolTip
-                    description={
-                      "Disable dynamically clicking of page buttons and links to find links, which resolve issues on some websites."
-                    }
-                    id="safe-mode-tooltip"
-                    showToolTip={showSafeModeTooltip}
-                  />
-                  <img
-                    className="tooltip-img"
-                    src={questionMarkIcon}
-                    checked={advancedOptions.safeMode}
-                    aria-describedby="safe-mode-tooltip"
-                    onFocus={() => handleSafeModeOnFocus()}
-                    onBlur={() => setShowSafeModeTooltip(false)}
-                    onMouseEnter={() => setShowSafeModeTooltip(true)}
-                    onMouseLeave={() => setShowSafeModeTooltip(false)}
-                    alt="tooltip icon for safe scan mode"
-                  />
-                </div>
-              </div>
-              <div id='follow-robots-toggle-group' class="advanced-options-toggle-group">
-                  <input 
-                    type="checkbox"
-                    id="follow-robots-toggle" 
-                    class="advanced-options-toggle"
-                    
-                    aria-describedby="follow-robots-tooltip"
-                    checked={advancedOptions.followRobots}
-                    onChange={handleSetAdvancedOption(
-                      "followRobots", 
-                      (e) => e.target.checked
-                    )} 
-                  /> 
-                  <label htmlFor="follow-robots-toggle">
-                    Adhere to robots.txt
-                  </label>
-              </div>
-            </>
+          <div id="max-concurrency-toggle-group" className="advanced-options-toggle-group">
+            <input
+              type="checkbox"
+              id="max-concurrency-toggle"
+              className="advanced-options-toggle"
+              aria-describedby="max-concurrency-tooltip"
+              checked={advancedOptions.maxConcurrency}
+              onFocus={() => handleMaxConcurrencyOnFocus()}
+              onBlur={() => setShowMaxConcurrencyTooltip(false)}
+              onMouseEnter={() => handleMaxConcurrencyOnMouseEnter()}
+              onMouseLeave={() => setIsMaxConcurrencyMouseEvent(false)}
+              onChange={handleSetAdvancedOption(
+                "maxConcurrency",
+                (e) => e.target.checked
+              )}
+            />
+            <label htmlFor="max-concurrency-toggle">Slow Scan Mode</label>
+            <div className="custom-tooltip-container">
+              <ToolTip
+                description={
+                  "Scan 1 page at a time instead of multiple pages concurrently."
+                }
+                id="max-concurrency-tooltip"
+                showToolTip={showMaxConcurrencyTooltip}
+              />
+              <img
+                className="tooltip-img"
+                src={questionMarkIcon}
+                aria-describedby="max-concurrency-tooltip"
+                checked={advancedOptions.maxConcurrency}
+                onFocus={() => handleMaxConcurrencyOnFocus()}
+                onBlur={() => setShowMaxConcurrencyTooltip(false)}
+                onMouseEnter={() => setShowMaxConcurrencyTooltip(true)}
+                onMouseLeave={() => setShowMaxConcurrencyTooltip(false)}
+                alt="tooltip icon for slow scan mode"
+              />
+            </div>
+          </div>
+          )}
+          {advancedOptions.scanType !== scanTypeOptions[2] && (
+          <div id='safe-mode-toggle-group' className="advanced-options-toggle-group">
+            <input 
+              type="checkbox"
+              id="safe-mode-toggle" 
+              className="advanced-options-toggle"
+              onFocus={() => handleSafeModeOnFocus()}
+              onBlur={() => setShowSafeModeTooltip(false)}
+              onMouseEnter={() => handleSafeModeOnMouseEnter()}
+              onMouseLeave={() => setIsSafeModeMouseEvent(false)}
+              aria-describedby="safe-mode-tooltip"
+              checked={advancedOptions.safeMode}
+              onChange={handleSetAdvancedOption(
+                "safeMode", 
+                (e) => e.target.checked
+              )} 
+            /> 
+            <label htmlFor="safe-mode-toggle">
+              Safe Scan Mode 
+            </label>
+            <div className="custom-tooltip-container">
+              <ToolTip
+                description={
+                  "Disable dynamically clicking of page buttons and links to find links, which resolve issues on some websites."
+                }
+                id="safe-mode-tooltip"
+                showToolTip={showSafeModeTooltip}
+              />
+              <img
+                className="tooltip-img"
+                src={questionMarkIcon}
+                checked={advancedOptions.safeMode}
+                aria-describedby="safe-mode-tooltip"
+                onFocus={() => handleSafeModeOnFocus()}
+                onBlur={() => setShowSafeModeTooltip(false)}
+                onMouseEnter={() => setShowSafeModeTooltip(true)}
+                onMouseLeave={() => setShowSafeModeTooltip(false)}
+                alt="tooltip icon for safe scan mode"
+              />
+            </div>
+          </div>
+          )}
+          {advancedOptions.scanType !== scanTypeOptions[2] && (
+          <div id='follow-robots-toggle-group' className="advanced-options-toggle-group">
+            <input 
+              type="checkbox"
+              id="follow-robots-toggle" 
+              className="advanced-options-toggle"
+              aria-describedby="follow-robots-tooltip"
+              checked={advancedOptions.followRobots}
+              onChange={handleSetAdvancedOption(
+                "followRobots", 
+                (e) => e.target.checked
+              )} 
+            /> 
+            <label htmlFor="follow-robots-toggle">
+              Adhere to robots.txt
+            </label>
+          </div>
           )}
           <hr />
           <div className="user-input-group">
@@ -330,20 +319,6 @@ const AdvancedScanOptions = ({
             </label>
             <DownloadFolderDropdown></DownloadFolderDropdown>
           </div>
-          {/* <div id="scan-in-background-toggle-group">
-            <input
-              type="checkbox"
-              id="scan-in-background-toggle"
-              checked={advancedOptions.scanInBackground}
-              onChange={handleSetAdvancedOption(
-                "scanInBackground",
-                (e) => e.target.checked
-              )}
-            />
-            <label htmlFor="scan-in-background-toggle">
-              Scan in background
-            </label>
-          </div> */}
         </div>
       )}
     </div>

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -24,6 +24,57 @@
     display: flex;
     align-items: center;
     flex-direction: column;
+
+    .toggle-url-file-tooltip-container {
+      button {
+        width: 60px;
+        height: 45px;
+        margin-right: 10px;
+        margin-left: -20px;
+        border: none;
+        border-right: 1px solid #b5c5ca;
+        background: none;
+        cursor: pointer;
+        font-weight: bold;
+        display: inline-block;
+        vertical-align: middle;
+        font-size: 14px;
+      }
+    }
+
+    #url-input {
+      display: block;
+      
+      &.hidden {
+        display: none;
+      }
+    }
+    
+    #file-input-container {
+      display: flex;
+      align-items: center;
+    }
+
+    #file-input {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    #file-input-label {
+      cursor: pointer;
+      display: inline-block;
+    }
+
+    #file-input-description {
+      display: none;
+    }
   }
 
   #url-bar-label {
@@ -106,8 +157,6 @@
     animation: 0.2s button-fade-in;
     z-index: 10;
     box-shadow: 0.25rem 0.25rem 0.5rem #b5c5ca;
-
-    // TODO find a better way to do the positioning
     margin-top: 0.75rem;
     margin-left: 4rem;
   }
@@ -149,7 +198,6 @@
     background-color: #f6f8f9;
     border: 1px solid #b5c5ca;
     border-radius: 0.5rem;
-    // width: 600px;
     max-width: 480px;
     position: absolute;
     left: 0;
@@ -302,6 +350,7 @@
     border-color: #D1DBDE;
     background-color: #E7ECEE;
   }
+
   #about-ph-modal .form-switch .form-check-input {
     height: 2rem;
     background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAyMCAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgZmlsdGVyPSJ1cmwoI2ZpbHRlcjBfZGRfMzAzNV8zMjc5MikiPgo8cmVjdCB4PSIzIiB5PSIyIiB3aWR0aD0iMTQiIGhlaWdodD0iMjYiIHJ4PSI2LjUiIGZpbGw9IndoaXRlIi8+CjwvZz4KPGRlZnM+CjxmaWx0ZXIgaWQ9ImZpbHRlcjBfZGRfMzAzNV8zMjc5MiIgeD0iMCIgeT0iMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjMyIiBmaWx0ZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIGNvbG9yLWludGVycG9sYXRpb24tZmlsdGVycz0ic1JHQiI+CjxmZUZsb29kIGZsb29kLW9wYWNpdHk9IjAiIHJlc3VsdD0iQmFja2dyb3VuZEltYWdlRml4Ii8+CjxmZUNvbG9yTWF0cml4IGluPSJTb3VyY2VBbHBoYSIgdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDEyNyAwIiByZXN1bHQ9ImhhcmRBbHBoYSIvPgo8ZmVPZmZzZXQgZHk9IjEiLz4KPGZlR2F1c3NpYW5CbHVyIHN0ZERldmlhdGlvbj0iMSIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjA2Mjc0NTEgMCAwIDAgMCAwLjA5NDExNzYgMCAwIDAgMCAwLjE1Njg2MyAwIDAgMCAwLjA2IDAiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbjI9IkJhY2tncm91bmRJbWFnZUZpeCIgcmVzdWx0PSJlZmZlY3QxX2Ryb3BTaGFkb3dfMzAzNV8zMjc5MiIvPgo8ZmVDb2xvck1hdHJpeCBpbj0iU291cmNlQWxwaGEiIHR5cGU9Im1hdHJpeCIgdmFsdWVzPSIwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAxMjcgMCIgcmVzdWx0PSJoYXJkQWxwaGEiLz4KPGZlT2Zmc2V0IGR5PSIxIi8+CjxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjEuNSIvPgo8ZmVDb2xvck1hdHJpeCB0eXBlPSJtYXRyaXgiIHZhbHVlcz0iMCAwIDAgMCAwLjA2Mjc0NTEgMCAwIDAgMCAwLjA5NDExNzYgMCAwIDAgMCAwLjE1Njg2MyAwIDAgMCAwLjEgMCIvPgo8ZmVCbGVuZCBtb2RlPSJub3JtYWwiIGluMj0iZWZmZWN0MV9kcm9wU2hhZG93XzMwMzVfMzI3OTIiIHJlc3VsdD0iZWZmZWN0Ml9kcm9wU2hhZG93XzMwMzVfMzI3OTIiLz4KPGZlQmxlbmQgbW9kZT0ibm9ybWFsIiBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJlZmZlY3QyX2Ryb3BTaGFkb3dfMzAzNV8zMjc5MiIgcmVzdWx0PSJzaGFwZSIvPgo8L2ZpbHRlcj4KPC9kZWZzPgo8L3N2Zz4=");
@@ -340,4 +389,17 @@
       opacity: 0;
     }
   }
+}
+
+// Additional styles for elements with inline styles
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -26,13 +26,16 @@
     flex-direction: column;
 
     .toggle-url-file-tooltip-container {
+      margin-left: -2px; 
+
       button {
         width: 60px;
         height: 45px;
-        margin-right: 10px;
-        margin-left: -20px;
+        margin-left: 0;
         border: none;
         border-right: 1px solid #b5c5ca;
+        border-top-left-radius: 50rem; 
+        border-bottom-left-radius: 50rem;
         background: none;
         cursor: pointer;
         font-weight: bold;
@@ -43,6 +46,7 @@
     }
 
     #url-input {
+      margin-left: 10px;
       display: block;
       
       &.hidden {
@@ -51,6 +55,7 @@
     }
     
     #file-input-container {
+      margin-left: 10px;
       display: flex;
       align-items: center;
     }
@@ -90,7 +95,7 @@
     width: 600px;
     max-width: 600px;
     display: flex;
-    padding: 2px 2px 2px 24px;
+    padding: 2px; // Remove left padding
     align-items: center;
     justify-content: space-between;
   }

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -51,6 +51,26 @@
     margin-right: 0.5rem;
   }
 
+  #file-input-container {
+    flex-grow: 1;
+    margin: 1rem 0;
+  }
+  
+  #file-input-label {
+    display: block;
+    width: 100%;
+    text-align: left;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+    color: #333333;
+  }
+  
+  #file-input {
+    display: none;
+  }
+
   #url-input:disabled {
     color: #6A8A95;
     background-color: transparent;

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -34,6 +34,8 @@
         margin-left: 0;
         border: none;
         border-right: 1px solid #b5c5ca;
+        border-top: 0.5px solid #b5c5ca;
+        border-bottom: 0.5px solid #b5c5ca;
         border-top-left-radius: 50rem; 
         border-bottom-left-radius: 50rem;
         background: none;

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -45,6 +45,24 @@
       }
     }
 
+    #file-input-container {
+      display: flex;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    .file-select-button {
+      margin: 0;
+      display: flex;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      margin-left: 5px;
+      background-color: white;
+      white-space: nowrap;
+      border: 0;
+      width: 100%;
+    }
+
     #url-input {
       margin-left: 10px;
       display: block;

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -74,7 +74,6 @@
 
     .file-select-button {
       margin: 0;
-      display: flex;
       text-overflow: ellipsis;
       overflow: hidden;
       margin-left: 5px;
@@ -82,6 +81,8 @@
       white-space: nowrap;
       border: 0;
       width: 100%;
+      display: block; 
+      text-align: left;
     }
 
     #url-input {

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -27,6 +27,14 @@
 
     .toggle-url-file-tooltip-container {
       margin-left: -2px; 
+      position: relative;
+      background-color: #F6F8F9;
+      border-top-left-radius: 50rem;
+      border-bottom-left-radius: 50rem;
+
+      &:hover {
+        background-color: #E7ECEE;
+      }
 
       button {
         width: 60px;
@@ -44,6 +52,17 @@
         display: inline-block;
         vertical-align: middle;
         font-size: 14px;
+      }
+
+      .custom-tooltip-description {
+        background-color: #333;
+        border-radius: 4px;
+        color: #fff;
+        font-size: 14px;
+        opacity: 95%;
+        padding: 5px;
+        width: 150px;
+        text-align: center;
       }
     }
 
@@ -109,7 +128,6 @@
     outline: none !important;
     border-bottom: 1px solid #785ef0;
   }
-
   #page-limit-toggle-button {
     padding: 0;
     margin-right: 0.875rem;
@@ -274,29 +292,6 @@
     background-repeat: no-repeat;
     background-size: 16px 12px;
     padding: 0.25rem 1.5rem 0.25rem 0.5rem;
-  }
-
-  .toggle-url-file-tooltip-container {
-    position: relative;
-    background-color: #F6F8F9;
-    border-top-left-radius: 50rem;
-    border-bottom-left-radius: 50rem;
-
-    &:hover {
-      background-color: #E7ECEE;
-    }
-
-  }
-
-  .toggle-url-file-tooltip-container .custom-tooltip-description {
-    background-color: #333;
-    border-radius: 4px;
-    color: #fff;
-    font-size: 14px;
-    opacity: 95%;
-    padding: 5px;
-    width: 150px;
-    text-align: center;
   }
 
   #edit-user-details {

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -53,33 +53,6 @@
         display: none;
       }
     }
-    
-    #file-input-container {
-      margin-left: 10px;
-      display: flex;
-      align-items: center;
-    }
-
-    #file-input {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0,0,0,0);
-      white-space: nowrap;
-      border: 0;
-    }
-
-    #file-input-label {
-      cursor: pointer;
-      display: inline-block;
-    }
-
-    #file-input-description {
-      display: none;
-    }
   }
 
   #url-bar-label {
@@ -105,26 +78,6 @@
     color: #333333;
     flex-grow: 1;
     margin-right: 0.5rem;
-  }
-
-  #file-input-container {
-    flex-grow: 1;
-    margin: 1rem 0;
-  }
-  
-  #file-input-label {
-    display: block;
-    width: 100%;
-    text-align: left;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    cursor: pointer;
-    color: #333333;
-  }
-  
-  #file-input {
-    display: none;
   }
 
   #url-input:disabled {
@@ -394,17 +347,4 @@
       opacity: 0;
     }
   }
-}
-
-// Additional styles for elements with inline styles
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  border: 0;
 }

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -250,6 +250,21 @@
     padding: 0.25rem 1.5rem 0.25rem 0.5rem;
   }
 
+  .toggle-url-file-tooltip-container {
+    position: relative;
+  }
+
+  .toggle-url-file-tooltip-container .custom-tooltip-description {
+    background-color: #333;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    opacity: 95%;
+    padding: 5px;
+    width: 150px;
+    text-align: center;
+  }
+
   #edit-user-details {
     background-color: #E7ECEE;
     border: none;

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -276,6 +276,14 @@
 
   .toggle-url-file-tooltip-container {
     position: relative;
+    background-color: #F6F8F9;
+    border-top-left-radius: 50rem;
+    border-bottom-left-radius: 50rem;
+
+    &:hover {
+      background-color: #E7ECEE;
+    }
+
   }
 
   .toggle-url-file-tooltip-container .custom-tooltip-description {

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -66,7 +66,7 @@
     }
 
     #url-input {
-      margin-left: 10px;
+      margin-left: 9px;
       display: block;
       
       &.hidden {

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -72,7 +72,7 @@ const InitScanForm = ({
 
   const getAllowedFileTypes = (scanType) => {
     if (scanType === scanTypeOptions[0]) {
-      return [".dhtml", ".html", ".htm", ".shtml", ".xhtml", ".pdf"];
+      return [".html", ".htm", ".shtml", ".xhtml", ".pdf"];
     } else if (scanType === scanTypeOptions[1]) {
       return [".xml", ".txt"];
     }

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -287,7 +287,7 @@ const InitScanForm = ({
             className="visually-hidden"
             aria-live="polite"
           ></div>
-          
+
           <input
             id="url-input"
             className={isCustomOptionChecked ? "hidden" : ""}
@@ -318,7 +318,7 @@ const InitScanForm = ({
               >
                 {scanUrl ? scanUrl : "Choose file"}
               </label>
-              <span id="file-input-description" style={{ display: "none" }}>
+              <span id="file-input-description">
                 Enter your local file to get started
               </span>
             </div>

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -40,11 +40,14 @@ const InitScanForm = ({
   const [staticHttpUrl, setStaticHttpUrl] = useState("https://");
   const [staticFilePath, setStaticFilePath] = useState("file:///");
   const [cachedNonFileScanType, setCachedNonFileScanType] = useState(() => {
-    return sessionStorage.getItem("cachedNonFileScanType") || scanTypeOptions[0];
+    return (
+      sessionStorage.getItem("cachedNonFileScanType") || scanTypeOptions[0]
+    );
   });
   const [displayScanType, setDisplayScanType] = useState(scanTypeOptions[0]);
   const [allowedFileTypes, setAllowedFileTypes] = useState([]);
-  const [showToggleUrlFileTooltip, setShowToggleUrlFileTooltip] = useState(false);
+  const [showToggleUrlFileTooltip, setShowToggleUrlFileTooltip] =
+    useState(false);
 
   if (isProxy) {
     delete viewportTypes.specific;
@@ -108,7 +111,9 @@ const InitScanForm = ({
         : cachedScanType || prevOptions.scanType,
     }));
 
-    setAllowedFileTypes(getAllowedFileTypes(cachedScanType || scanTypeOptions[0]));
+    setAllowedFileTypes(
+      getAllowedFileTypes(cachedScanType || scanTypeOptions[0])
+    );
   }, []);
 
   useEffect(() => {
@@ -118,8 +123,14 @@ const InitScanForm = ({
       setStaticHttpUrl(scanUrl);
     }
 
-    sessionStorage.setItem("isCustomOptionChecked", JSON.stringify(isCustomOptionChecked));
-    sessionStorage.setItem("scanType", isCustomOptionChecked ? scanTypeOptions[3] : displayScanType);
+    sessionStorage.setItem(
+      "isCustomOptionChecked",
+      JSON.stringify(isCustomOptionChecked)
+    );
+    sessionStorage.setItem(
+      "scanType",
+      isCustomOptionChecked ? scanTypeOptions[3] : displayScanType
+    );
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
     sessionStorage.setItem("cachedNonFileScanType", cachedNonFileScanType);
   }, [isCustomOptionChecked, scanUrl, displayScanType, cachedNonFileScanType]);
@@ -154,7 +165,11 @@ const InitScanForm = ({
     if (isCustomOptionChecked) {
       const fileExtension = "." + scanUrl.split(".").pop().toLowerCase();
       if (!allowedFileTypes.includes(fileExtension)) {
-        alert(`Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(", ")}`);
+        alert(
+          `Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(
+            ", "
+          )}`
+        );
         return;
       }
     }
@@ -187,13 +202,20 @@ const InitScanForm = ({
     const file = e.target.files[0];
     if (file) {
       const fileExtension = "." + file.name.split(".").pop().toLowerCase();
-      if (allowedFileTypes.includes(fileExtension) || (fileExtension === ".txt" && allowedFileTypes.includes(".txt"))) {
+      if (
+        allowedFileTypes.includes(fileExtension) ||
+        (fileExtension === ".txt" && allowedFileTypes.includes(".txt"))
+      ) {
         const readablePath = convertToReadablePath(file.path);
         setScanUrl(readablePath);
         setStaticFilePath(readablePath);
         setSelectedFile(file);
       } else {
-        alert(`Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(", ")}`);
+        alert(
+          `Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(
+            ", "
+          )}`
+        );
         e.target.value = "";
       }
     }
@@ -216,86 +238,71 @@ const InitScanForm = ({
       }));
       setDisplayScanType(cachedNonFileScanType);
     }
-    const announcement = newState ? "File input type selected" : "URL input type selected";
+    const announcement = newState
+      ? "File input type selected"
+      : "URL input type selected";
     document.getElementById("announcement").textContent = announcement;
   };
 
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        Enter your {isCustomOptionChecked ? "local file": "URL"} to get started
+        Enter your {isCustomOptionChecked ? "local file" : <strong>URL</strong>}{" "}
+        to get started
       </label>
       <div id="url-bar-group">
         <div id="url-bar">
-        {advancedOptions.scanType !== scanTypeOptions[2] && (
-          <div 
-            className="toggle-url-file-tooltip-container"
-            onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
-            onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
-            onFocus={() => setShowToggleUrlFileTooltip(true)}
-            onBlur={() => setShowToggleUrlFileTooltip(false)}
-          >
-            <button
-              type="button"
-              onClick={toggleScanType}
-              aria-describedby="toggle-url-file-tooltip-text"
-              style={{
-                width: "60px",
-                height: "45px",
-                marginRight: "10px",
-                marginLeft: "-20px",
-                border: "none",
-                borderRight: "1px solid #b5c5ca",
-                background: "none",
-                cursor: "pointer",
-                fontWeight: "bold",
-                display: "inline-block",
-                verticalAlign: "middle",
-                fontSize: "14px",
-              }}
+          {advancedOptions.scanType !== scanTypeOptions[2] && (
+            <div
+              className="toggle-url-file-tooltip-container"
+              onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
+              onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
+              onFocus={() => setShowToggleUrlFileTooltip(true)}
+              onBlur={() => setShowToggleUrlFileTooltip(false)}
             >
-              {isCustomOptionChecked ? "FILE" : "URL"}
-            </button>
-            <span id="toggle-url-file-tooltip-text" className="visually-hidden">
-              {`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
-            </span>
-            <ToolTip
-              description={`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
-              id="toggle-url-file-tooltip"
-              showToolTip={showToggleUrlFileTooltip}
-            />
-          </div>
-        )}
-
+              <button
+                type="button"
+                onClick={toggleScanType}
+                aria-describedby="toggle-url-file-tooltip-text"
+              >
+                {isCustomOptionChecked ? "FILE" : "URL"}
+              </button>
+              <span
+                id="toggle-url-file-tooltip-text"
+                className="visually-hidden"
+              >
+                {`Switch to ${isCustomOptionChecked ? "URL" : "file"} input`}
+              </span>
+              <ToolTip
+                description={`Switch to ${
+                  isCustomOptionChecked ? "URL" : "file"
+                } input`}
+                id="toggle-url-file-tooltip"
+                showToolTip={showToggleUrlFileTooltip}
+              />
+            </div>
+          )}
+          <div
+            id="announcement"
+            className="visually-hidden"
+            aria-live="polite"
+          ></div>
+          
           <input
             id="url-input"
+            className={isCustomOptionChecked ? "hidden" : ""}
             type="text"
             value={scanUrl}
             onChange={(e) => setScanUrl(e.target.value)}
-            style={{
-              display: isCustomOptionChecked ? "none" : "block",
-            }}
           />
           {isCustomOptionChecked && (
-            <div id="file-input-container" style={{ display: "flex", alignItems: "center" }}>
+            <div id="file-input-container">
               <input
                 type="file"
                 id="file-input"
                 accept={allowedFileTypes.join(",")}
                 onChange={handleFileChange}
-                aria-label="Choose file"
                 tabIndex="0"
-                style={{
-                  position: "absolute",
-                  width: "1px",
-                  height: "1px",
-                  padding: "0",
-                  margin: "-1px",
-                  overflow: "hidden",
-                  clip: "rect(0,0,0,0)",
-                  whiteSpace: "nowrap",
-                  border: "0",
-                }}
               />
               <label
                 htmlFor="file-input"
@@ -307,10 +314,13 @@ const InitScanForm = ({
                     document.getElementById("file-input").click();
                   }
                 }}
-                style={{ cursor: "pointer", display: "inline-block" }}
+                aria-describedby="file-input-description"
               >
                 {scanUrl ? scanUrl : "Choose file"}
               </label>
+              <span id="file-input-description" style={{ display: "none" }}>
+                Enter your local file to get started
+              </span>
             </div>
           )}
 
@@ -327,9 +337,15 @@ const InitScanForm = ({
                   <span className="purple-text">
                     {pageLimit} {pageWord}{" "}
                     {openPageLimitAdjuster ? (
-                      <ButtonSvgIcon className={`chevron-up-icon`} svgIcon={<ChevronUpIcon />} />
+                      <ButtonSvgIcon
+                        className={`chevron-up-icon`}
+                        svgIcon={<ChevronUpIcon />}
+                      />
                     ) : (
-                      <ButtonSvgIcon className={`chevron-down-icon`} svgIcon={<ChevronDownIcon />} />
+                      <ButtonSvgIcon
+                        className={`chevron-down-icon`}
+                        svgIcon={<ChevronDownIcon />}
+                      />
                     )}
                   </span>
                 </Button>
@@ -361,7 +377,11 @@ const InitScanForm = ({
             onClick={handleScanButtonClicked}
             disabled={scanButtonIsClicked || isAbortingScan}
           >
-            {scanButtonIsClicked || isAbortingScan ? <LoadingSpinner></LoadingSpinner> : "Scan"}
+            {scanButtonIsClicked || isAbortingScan ? (
+              <LoadingSpinner></LoadingSpinner>
+            ) : (
+              "Scan"
+            )}
           </Button>
         </div>
 
@@ -377,7 +397,8 @@ const InitScanForm = ({
         scanTypeOptions={
           isCustomOptionChecked
             ? scanTypeOptions.filter(
-                (option) => option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
+                (option) =>
+                  option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
               )
             : scanTypeOptions.filter((option) => option !== scanTypeOptions[3])
         }
@@ -386,7 +407,9 @@ const InitScanForm = ({
         deviceOptions={deviceOptions}
         advancedOptions={{
           ...advancedOptions,
-          scanType: isCustomOptionChecked ? displayScanType : advancedOptions.scanType,
+          scanType: isCustomOptionChecked
+            ? displayScanType
+            : advancedOptions.scanType,
         }}
         setAdvancedOptions={(newOptions) => {
           if (!isCustomOptionChecked) {

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -261,8 +261,6 @@ const InitScanForm = ({
           </div>
           )}
 
-          <div id="announcement" aria-live="polite" className="visually-hidden"></div>
-
           <input
             id="url-input"
             type="text"

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -258,7 +258,7 @@ const InitScanForm = ({
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        {isCustomOptionChecked ? "Select" : "Enter"} {" "}
+        {isCustomOptionChecked ? "Select " : "Enter "} 
         your{" "}
         <strong>{isCustomOptionChecked ? "local file" : "URL"} </strong>
         to get started

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -68,8 +68,8 @@ const InitScanForm = ({
       : getDefaultAdvancedOptions(isProxy);
   });
 
-  const [isCustomOptionChecked, setIsCustomOptionChecked] = useState(() => {
-    const cachedCheckboxState = sessionStorage.getItem("isCustomOptionChecked");
+  const [isFileOptionChecked, setIsFileOptionChecked] = useState(() => {
+    const cachedCheckboxState = sessionStorage.getItem("isFileOptionChecked");
     return cachedCheckboxState ? JSON.parse(cachedCheckboxState) : false;
   });
 
@@ -88,14 +88,14 @@ const InitScanForm = ({
     const wasLocalFileScan = cachedScanType === scanTypeOptions[3];
 
     if (wasLocalFileScan) {
-      setIsCustomOptionChecked(true);
+      setIsFileOptionChecked(true);
       const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "Choose file...";
       setScanUrl(newScanUrl);
       setStaticFilePath(newScanUrl);
       setStaticHttpUrl("https://");
       setDisplayScanType(cachedNonFileScanType);
     } else {
-      setIsCustomOptionChecked(false);
+      setIsFileOptionChecked(false);
       const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "https://";
       setScanUrl(newScanUrl);
       setStaticHttpUrl(newScanUrl);
@@ -117,23 +117,23 @@ const InitScanForm = ({
   }, []);
 
   useEffect(() => {
-    if (isCustomOptionChecked) {
+    if (isFileOptionChecked) {
       setStaticFilePath(scanUrl);
     } else {
       setStaticHttpUrl(scanUrl);
     }
 
     sessionStorage.setItem(
-      "isCustomOptionChecked",
-      JSON.stringify(isCustomOptionChecked)
+      "isFileOptionChecked",
+      JSON.stringify(isFileOptionChecked)
     );
     sessionStorage.setItem(
       "scanType",
-      isCustomOptionChecked ? scanTypeOptions[3] : displayScanType
+      isFileOptionChecked ? scanTypeOptions[3] : displayScanType
     );
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
     sessionStorage.setItem("cachedNonFileScanType", cachedNonFileScanType);
-  }, [isCustomOptionChecked, scanUrl, displayScanType, cachedNonFileScanType]);
+  }, [isFileOptionChecked, scanUrl, displayScanType, cachedNonFileScanType]);
 
   useEffect(() => {
     const urlBarElem = document.getElementById("url-bar");
@@ -162,7 +162,7 @@ const InitScanForm = ({
   };
 
   const handleScanButtonClicked = () => {
-    if (isCustomOptionChecked) {
+    if (isFileOptionChecked) {
       const fileExtension = "." + scanUrl.split(".").pop().toLowerCase();
       if (!allowedFileTypes.includes(fileExtension)) {
         alert(
@@ -184,7 +184,7 @@ const InitScanForm = ({
     sessionStorage.setItem("advancedOptions", JSON.stringify(advancedOptions));
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
 
-    if (isCustomOptionChecked) {
+    if (isFileOptionChecked) {
       setStaticFilePath(scanUrl);
       startScan({
         file: selectedFile,
@@ -237,8 +237,8 @@ const InitScanForm = ({
   };
 
   const toggleScanType = () => {
-    const newState = !isCustomOptionChecked;
-    setIsCustomOptionChecked(newState);
+    const newState = !isFileOptionChecked;
+    setIsFileOptionChecked(newState);
     setScanUrl(newState ? staticFilePath : staticHttpUrl);
     if (newState) {
       setCachedNonFileScanType(displayScanType);
@@ -258,9 +258,9 @@ const InitScanForm = ({
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        {isCustomOptionChecked ? "Select " : "Enter "} 
+        {isFileOptionChecked ? "Select " : "Enter "} 
         your{" "}
-        <strong>{isCustomOptionChecked ? "local file" : "URL"} </strong>
+        <strong>{isFileOptionChecked ? "local file" : "URL"} </strong>
         to get started
       </label>
       <div id="url-bar-group">
@@ -278,11 +278,11 @@ const InitScanForm = ({
                 onClick={toggleScanType}
                 aria-describedby="toggle-url-file-tooltip"
               >
-                {isCustomOptionChecked ? "FILE" : "URL"}
+                {isFileOptionChecked ? "FILE" : "URL"}
               </button>
               <ToolTip
                 description={`Toggle to ${
-                  isCustomOptionChecked ? "URL" : "file"
+                  isFileOptionChecked ? "URL" : "file"
                 } input`}
                 id="toggle-url-file-tooltip"
                 showToolTip={showToggleUrlFileTooltip}
@@ -290,7 +290,7 @@ const InitScanForm = ({
             </div>
           )}
 
-          {!isCustomOptionChecked && (
+          {!isFileOptionChecked && (
             <input
               id="url-input"
               type="text"
@@ -299,7 +299,7 @@ const InitScanForm = ({
             />
           )}
 
-          {isCustomOptionChecked && (
+          {isFileOptionChecked && (
             <div id="file-input-container">
               <button
                 id="file-select-button"
@@ -315,7 +315,7 @@ const InitScanForm = ({
 
           {advancedOptions.scanType !== scanTypeOptions[2] &&
             advancedOptions.scanType !== scanTypeOptions[3] &&
-            !isCustomOptionChecked && (
+            !isFileOptionChecked && (
               <div>
                 <Button
                   type="btn-link"
@@ -384,7 +384,7 @@ const InitScanForm = ({
       <AdvancedScanOptions
         isProxy={isProxy}
         scanTypeOptions={
-          isCustomOptionChecked
+          isFileOptionChecked
             ? scanTypeOptions.filter(
                 (option) =>
                   option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
@@ -396,12 +396,12 @@ const InitScanForm = ({
         deviceOptions={deviceOptions}
         advancedOptions={{
           ...advancedOptions,
-          scanType: isCustomOptionChecked
+          scanType: isFileOptionChecked
             ? displayScanType
             : advancedOptions.scanType,
         }}
         setAdvancedOptions={(newOptions) => {
-          if (!isCustomOptionChecked) {
+          if (!isFileOptionChecked) {
             setAdvancedOptions(newOptions);
             setDisplayScanType(newOptions.scanType);
             setCachedNonFileScanType(newOptions.scanType);
@@ -417,7 +417,7 @@ const InitScanForm = ({
           setAllowedFileTypes(getAllowedFileTypes(newOptions.scanType));
         }}
         scanButtonIsClicked={scanButtonIsClicked}
-        isCustomOptionChecked={isCustomOptionChecked}
+        isFileOptionChecked={isFileOptionChecked}
       />
     </div>
   );

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -39,6 +39,7 @@ const InitScanForm = ({
   const [staticHttpUrl, setStaticHttpUrl] = useState("https://");
   const [staticFilePath, setStaticFilePath] = useState("file:///");
   const [cachedNonFileScanType, setCachedNonFileScanType] = useState(scanTypeOptions[0]);
+  const [displayScanType, setDisplayScanType] = useState(scanTypeOptions[0]);
 
   if (isProxy) {
     delete viewportTypes.specific;
@@ -75,6 +76,7 @@ const InitScanForm = ({
       setScanUrl(newScanUrl);
       setStaticFilePath(newScanUrl);
       setStaticHttpUrl("https://");
+      setDisplayScanType(cachedNonFileScanType);
     } else {
       setIsCustomOptionChecked(false);
       const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "https://";
@@ -82,6 +84,7 @@ const InitScanForm = ({
       setStaticHttpUrl(newScanUrl);
       setStaticFilePath("file:///");
       setCachedNonFileScanType(cachedScanType || scanTypeOptions[0]);
+      setDisplayScanType(cachedScanType || scanTypeOptions[0]);
     }
 
     setAdvancedOptions((prevOptions) => ({
@@ -145,7 +148,7 @@ const InitScanForm = ({
     }
 
     if (isCustomOptionChecked) {
-      startScan({ file: selectedFile, scanUrl, ...advancedOptions });
+      startScan({ file: selectedFile, scanUrl, ...advancedOptions, scanType: scanTypeOptions[3] });
     } else {
       startScan({ scanUrl: scanUrl.trim(), pageLimit, ...advancedOptions });
     }
@@ -205,6 +208,7 @@ const InitScanForm = ({
                     ...prevOptions,
                     scanType: cachedNonFileScanType,
                   }));
+                  setDisplayScanType(cachedNonFileScanType);
                 }
               }}
             />
@@ -305,8 +309,16 @@ const InitScanForm = ({
         fileTypesOptions={fileTypesOptions}
         viewportOptions={viewportOptions}
         deviceOptions={deviceOptions}
-        advancedOptions={advancedOptions}
-        setAdvancedOptions={setAdvancedOptions}
+        advancedOptions={{...advancedOptions, scanType: isCustomOptionChecked ? displayScanType : advancedOptions.scanType}}
+        setAdvancedOptions={(newOptions) => {
+          if (!isCustomOptionChecked) {
+            setAdvancedOptions(newOptions);
+            setDisplayScanType(newOptions.scanType);
+          } else {
+            setDisplayScanType(newOptions.scanType);
+            setCachedNonFileScanType(newOptions.scanType);
+          }
+        }}
         scanButtonIsClicked={scanButtonIsClicked}
       />
     </div>

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -275,16 +275,10 @@ const InitScanForm = ({
               <button
                 type="button"
                 onClick={toggleScanType}
-                aria-describedby="toggle-url-file-tooltip-text"
+                aria-describedby="toggle-url-file-tooltip"
               >
                 {isCustomOptionChecked ? "FILE" : "URL"}
               </button>
-              <span
-                id="toggle-url-file-tooltip-text"
-                className="visually-hidden"
-              >
-                {`Switch to ${isCustomOptionChecked ? "URL" : "file"} input`}
-              </span>
               <ToolTip
                 description={`Switch to ${
                   isCustomOptionChecked ? "URL" : "file"
@@ -323,7 +317,7 @@ const InitScanForm = ({
                   width: "100%",
                 }}
               >
-                <span>{scanUrl ? scanUrl : "Choose file"}</span>
+                {scanUrl ? scanUrl : "Choose file"}
               </button>
             </div>
           )}
@@ -335,20 +329,19 @@ const InitScanForm = ({
                 <Button
                   type="btn-link"
                   id="page-limit-toggle-button"
-                  onClick={togglePageLimitAdjuster}
-                  disabled={scanButtonIsClicked}
+                  onClick={(e) => togglePageLimitAdjuster(e)}	
                 >
                   capped at{" "}
                   <span className="purple-text">
                     {pageLimit} {pageWord}{" "}
                     {openPageLimitAdjuster ? (
                       <ButtonSvgIcon
-                        className="chevron-up-icon"
+                        className={`chevron-up-icon`}
                         svgIcon={<ChevronUpIcon />}
                       />
                     ) : (
                       <ButtonSvgIcon
-                        className="chevron-down-icon"
+                        className={`chevron-down-icon`}
                         svgIcon={<ChevronDownIcon />}
                       />
                     )}
@@ -356,7 +349,7 @@ const InitScanForm = ({
                 </Button>
 
                 {openPageLimitAdjuster && (
-                  <div id="page-limit-adjuster">
+                  <div id="page-limit-adjuster" ref={pageLimitAdjuster}>
                     <input
                       type="number"
                       id="page-limit-input"

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -38,6 +38,7 @@ const InitScanForm = ({
   const [scanUrl, setScanUrl] = useState("");
   const [staticHttpUrl, setStaticHttpUrl] = useState("https://");
   const [staticFilePath, setStaticFilePath] = useState("file:///");
+  const [cachedNonFileScanType, setCachedNonFileScanType] = useState(scanTypeOptions[0]);
 
   if (isProxy) {
     delete viewportTypes.specific;
@@ -80,6 +81,7 @@ const InitScanForm = ({
       setScanUrl(newScanUrl);
       setStaticHttpUrl(newScanUrl);
       setStaticFilePath("file:///");
+      setCachedNonFileScanType(cachedScanType || scanTypeOptions[0]);
     }
 
     setAdvancedOptions((prevOptions) => ({
@@ -193,17 +195,15 @@ const InitScanForm = ({
                 setIsCustomOptionChecked(newCheckedState);
                 setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
                 if (newCheckedState) {
+                  setCachedNonFileScanType(advancedOptions.scanType);
                   setAdvancedOptions((prevOptions) => ({
                     ...prevOptions,
                     scanType: scanTypeOptions[3],
                   }));
                 } else {
-                  // Revert to the previous non-file scan type or default to website crawl
                   setAdvancedOptions((prevOptions) => ({
                     ...prevOptions,
-                    scanType: prevOptions.scanType === scanTypeOptions[3] 
-                      ? scanTypeOptions[0] 
-                      : prevOptions.scanType,
+                    scanType: cachedNonFileScanType,
                   }));
                 }
               }}

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -228,10 +228,14 @@ const InitScanForm = ({
       <div id="url-bar-group">
         <div id="url-bar">
           {advancedOptions.scanType !== scanTypeOptions[2] && (
+            <div className="toggle-url-file-tooltip-container"
+            onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
+            onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
+          >
             <button
               type="button"
               onClick={toggleScanType}
-              aria-label={`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
+              aria-describedby= "toggle-url-file-tooltip"
               style={{
                 width: "60px",
                 height: "45px",
@@ -249,6 +253,12 @@ const InitScanForm = ({
             >
               {isCustomOptionChecked ? "FILE" : "URL"}
             </button>
+            <ToolTip
+              description={`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
+              id="toggle-url-file-tooltip"
+              showToolTip={showToggleUrlFileTooltip}
+            />
+          </div>
           )}
 
           <div id="announcement" aria-live="polite" className="visually-hidden"></div>

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -223,19 +223,22 @@ const InitScanForm = ({
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        Enter your {isCustomOptionChecked ? "local file": <strong>URL</strong>} to get started
+        Enter your {isCustomOptionChecked ? "local file": "URL"} to get started
       </label>
       <div id="url-bar-group">
         <div id="url-bar">
-          {advancedOptions.scanType !== scanTypeOptions[2] && (
-            <div className="toggle-url-file-tooltip-container"
+        {advancedOptions.scanType !== scanTypeOptions[2] && (
+          <div 
+            className="toggle-url-file-tooltip-container"
             onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
             onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
+            onFocus={() => setShowToggleUrlFileTooltip(true)}
+            onBlur={() => setShowToggleUrlFileTooltip(false)}
           >
             <button
               type="button"
               onClick={toggleScanType}
-              aria-describedby= "toggle-url-file-tooltip"
+              aria-describedby="toggle-url-file-tooltip-text"
               style={{
                 width: "60px",
                 height: "45px",
@@ -253,13 +256,16 @@ const InitScanForm = ({
             >
               {isCustomOptionChecked ? "FILE" : "URL"}
             </button>
+            <span id="toggle-url-file-tooltip-text" className="visually-hidden">
+              {`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
+            </span>
             <ToolTip
               description={`Switch to ${isCustomOptionChecked ? 'URL' : 'file'} input`}
               id="toggle-url-file-tooltip"
               showToolTip={showToggleUrlFileTooltip}
             />
           </div>
-          )}
+        )}
 
           <input
             id="url-input"

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -299,23 +299,13 @@ const InitScanForm = ({
           )}
 
           {isCustomOptionChecked && (
-            <div style={{ display: "flex", width: "100%", overflow: "hidden" }}>
+            <div id="file-input-container">
               <button
                 id="file-select-button"
                 onClick={handleFileSelect}
                 disabled={scanButtonIsClicked}
                 aria-describedby="url-bar-label"
-                style={{
-                  margin: 0,
-                  display: "flex",
-                  textOverflow: "ellipsis",
-                  overflow: "hidden",
-                  marginLeft: "10px",
-                  backgroundColor: "white",
-                  whiteSpace: "nowrap",
-                  border: 0,
-                  width: "100%",
-                }}
+                className="file-select-button"
               >
                 {scanUrl ? scanUrl : "Choose file"}
               </button>

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -73,7 +73,7 @@ const InitScanForm = ({
     const cachedScanUrl = sessionStorage.getItem("scanUrl");
     const cachedScanType = sessionStorage.getItem("scanType");
     const wasLocalFileScan = cachedScanType === scanTypeOptions[3];
-  
+
     if (wasLocalFileScan) {
       setIsCustomOptionChecked(true);
       const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "file:///";
@@ -85,7 +85,7 @@ const InitScanForm = ({
       setScanUrl(newScanUrl);
       setStaticHttpUrl(newScanUrl);
     }
-  
+
     setAdvancedOptions((prevOptions) => ({
       ...prevOptions,
       scanType: wasLocalFileScan ? scanTypeOptions[3] : scanTypeOptions[0],
@@ -94,20 +94,24 @@ const InitScanForm = ({
 
   useEffect(() => {
     if (isCustomOptionChecked) {
-      setScanUrl(prevScanUrl => prevScanUrl.startsWith("file:///") ? prevScanUrl : "file:///");
-      setStaticFilePath(prevPath => prevPath.startsWith("file:///") ? prevPath : "file:///");
+      setStaticFilePath(scanUrl);
     } else {
-      setScanUrl(prevScanUrl => prevScanUrl.startsWith("https://") ? prevScanUrl : "https://");
-      setStaticHttpUrl(prevUrl => prevUrl.startsWith("https://") ? prevUrl : "https://");
+      setStaticHttpUrl(scanUrl);
     }
-  
+
     setAdvancedOptions((prevOptions) => ({
       ...prevOptions,
       scanType: isCustomOptionChecked ? scanTypeOptions[3] : scanTypeOptions[0],
     }));
-  
-    sessionStorage.setItem("isCustomOptionChecked", JSON.stringify(isCustomOptionChecked));
-    sessionStorage.setItem("scanType", isCustomOptionChecked ? scanTypeOptions[3] : scanTypeOptions[0]);
+
+    sessionStorage.setItem(
+      "isCustomOptionChecked",
+      JSON.stringify(isCustomOptionChecked)
+    );
+    sessionStorage.setItem(
+      "scanType",
+      isCustomOptionChecked ? scanTypeOptions[3] : scanTypeOptions[0]
+    );
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
   }, [isCustomOptionChecked, scanUrl]);
 
@@ -133,32 +137,6 @@ const InitScanForm = ({
     }
   };
 
-  const CachedValuesDisplay = ({ 
-    pageLimit, 
-    advancedOptions, 
-    scanUrl, 
-    isCustomOptionChecked 
-  }) => {
-    return (
-      <div className="cached-values-display" style={{ 
-        fontSize: '12px', 
-        marginBottom: '10px', 
-        padding: '10px', 
-        border: '1px solid #ccc', 
-        borderRadius: '5px' 
-      }}>
-        <h4>Cached Values:</h4>
-        <p>Page Limit: {pageLimit}</p>
-        <p>Scan URL: {scanUrl}</p>
-        <p>Is Custom Option Checked: {isCustomOptionChecked.toString()}</p>
-        <details>
-          <summary>Advanced Options</summary>
-          <pre>{JSON.stringify(advancedOptions, null, 2)}</pre>
-        </details>
-      </div>
-    );
-  };
-
   const handleScanButtonClicked = () => {
     if (isProxy && advancedOptions.viewport === viewportTypes.mobile) {
       advancedOptions.viewport = viewportTypes.custom;
@@ -169,6 +147,7 @@ const InitScanForm = ({
     sessionStorage.setItem("pageLimit", JSON.stringify(pageLimit));
     sessionStorage.setItem("advancedOptions", JSON.stringify(advancedOptions));
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
+
     if (isCustomOptionChecked) {
       setStaticFilePath(scanUrl);
     } else {
@@ -233,6 +212,7 @@ const InitScanForm = ({
               onChange={(e) => {
                 const newCheckedState = e.target.checked;
                 setIsCustomOptionChecked(newCheckedState);
+                setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
                 setAdvancedOptions((prevOptions) => ({
                   ...prevOptions,
                   scanType: newCheckedState
@@ -332,12 +312,6 @@ const InitScanForm = ({
           </span>
         )}
       </div>
-      <CachedValuesDisplay
-      pageLimit={pageLimit}
-      advancedOptions={advancedOptions}
-      scanUrl={scanUrl}
-      isCustomOptionChecked={isCustomOptionChecked}
-    />
 
       <AdvancedScanOptions
         isProxy={isProxy}

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -48,6 +48,7 @@ const InitScanForm = ({
   const [allowedFileTypes, setAllowedFileTypes] = useState([]);
   const [showToggleUrlFileTooltip, setShowToggleUrlFileTooltip] =
     useState(false);
+  const toggleUrlFileRef = useRef(null);
 
   if (isProxy) {
     delete viewportTypes.specific;
@@ -253,6 +254,13 @@ const InitScanForm = ({
       }));
       setDisplayScanType(cachedNonFileScanType);
     }
+    // Have screenreader to focus and announce the button
+    if (toggleUrlFileRef.current) {
+      toggleUrlFileRef.current.blur();
+      setTimeout(() => {
+        toggleUrlFileRef.current.focus();
+      }, 10);
+    }
   };
 
   return (
@@ -267,26 +275,27 @@ const InitScanForm = ({
         <div id="url-bar">
           {advancedOptions.scanType !== scanTypeOptions[2] && (
             <div
-              className="toggle-url-file-tooltip-container"
-              onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
-              onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
-              onFocus={() => setShowToggleUrlFileTooltip(true)}
-              onBlur={() => setShowToggleUrlFileTooltip(false)}
-            >
+             className="toggle-url-file-tooltip-container"
+             onMouseEnter={() => setShowToggleUrlFileTooltip(true)}
+             onMouseLeave={() => setShowToggleUrlFileTooltip(false)}
+             onFocus={() => setShowToggleUrlFileTooltip(true)}
+             onBlur={() => setShowToggleUrlFileTooltip(false)}
+           >
               <button
-                type="button"
-                onClick={toggleScanType}
-                aria-describedby="toggle-url-file-tooltip"
+               type="button"
+               onClick={toggleScanType}
+               aria-describedby="toggle-url-file-tooltip"
+               ref={toggleUrlFileRef}
               >
-                {isFileOptionChecked ? "FILE" : "URL"}
+               {isFileOptionChecked ? "FILE" : "URL"}
               </button>
               <ToolTip
                 description={`Toggle to ${
-                  isFileOptionChecked ? "URL" : "file"
-                } input`}
+                 isFileOptionChecked ? "URL" : "file"
+               } input`}
                 id="toggle-url-file-tooltip"
                 showToolTip={showToggleUrlFileTooltip}
-              />
+             />
             </div>
           )}
 

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -68,6 +68,15 @@ const InitScanForm = ({
     return cachedCheckboxState ? JSON.parse(cachedCheckboxState) : false;
   });
 
+  const getAllowedFileTypes = (scanType) => {
+    if (scanType === scanTypeOptions[0]) {
+      return [".dhtml", ".html", ".htm", ".shtml", ".xhtml", ".pdf"];
+    } else if (scanType === scanTypeOptions[1]) {
+      return [".xml", ".txt"];
+    }
+    return [];
+  };
+
   useEffect(() => {
     const cachedScanUrl = sessionStorage.getItem("scanUrl");
     const cachedScanType = sessionStorage.getItem("scanType");
@@ -106,10 +115,10 @@ const InitScanForm = ({
     }
 
     sessionStorage.setItem("isCustomOptionChecked", JSON.stringify(isCustomOptionChecked));
-    sessionStorage.setItem("scanType", advancedOptions.scanType);
+    sessionStorage.setItem("scanType", isCustomOptionChecked ? scanTypeOptions[3] : displayScanType);
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
     sessionStorage.setItem("cachedNonFileScanType", cachedNonFileScanType);
-  }, [isCustomOptionChecked, scanUrl, advancedOptions.scanType, cachedNonFileScanType]);
+  }, [isCustomOptionChecked, scanUrl, displayScanType, cachedNonFileScanType]);
 
   useEffect(() => {
     const urlBarElem = document.getElementById("url-bar");
@@ -122,14 +131,9 @@ const InitScanForm = ({
     setPageWord(pageLimit === "1" ? "page" : "pages");
   }, [pageLimit]);
 
-  const getAllowedFileTypes = (scanType) => {
-    if (scanType === scanTypeOptions[0]) {
-      return [".dhtml", ".html", ".htm", ".shtml", ".xhtml", ".pdf"];
-    } else if (scanType === scanTypeOptions[1]) {
-      return [".xml", ".txt"];
-    }
-    return [];
-  };
+  useEffect(() => {
+    setAllowedFileTypes(getAllowedFileTypes(displayScanType));
+  }, [displayScanType]);
 
   const togglePageLimitAdjuster = (e) => {
     if (!e.currentTarget.disabled) {
@@ -203,12 +207,11 @@ const InitScanForm = ({
                   setIsCustomOptionChecked(newCheckedState);
                   setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
                   if (newCheckedState) {
-                    setCachedNonFileScanType(advancedOptions.scanType);
+                    setCachedNonFileScanType(displayScanType);
                     setAdvancedOptions((prevOptions) => ({
                       ...prevOptions,
                       scanType: scanTypeOptions[3],
                     }));
-                    setAllowedFileTypes(getAllowedFileTypes(advancedOptions.scanType));
                   } else {
                     setAdvancedOptions((prevOptions) => ({
                       ...prevOptions,
@@ -326,6 +329,7 @@ const InitScanForm = ({
             setDisplayScanType(newOptions.scanType);
             setCachedNonFileScanType(newOptions.scanType);
           }
+          setAllowedFileTypes(getAllowedFileTypes(newOptions.scanType));
         }}
         scanButtonIsClicked={scanButtonIsClicked}
       />

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -238,16 +238,12 @@ const InitScanForm = ({
       }));
       setDisplayScanType(cachedNonFileScanType);
     }
-    const announcement = newState
-      ? "File input type selected"
-      : "URL input type selected";
-    document.getElementById("announcement").textContent = announcement;
   };
 
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        Enter your {isCustomOptionChecked ? "local file" : <strong>URL</strong>}{" "}
+        Enter your <strong>{isCustomOptionChecked ? "local file" : "URL"}{" "}</strong>
         to get started
       </label>
       <div id="url-bar-group">
@@ -282,11 +278,7 @@ const InitScanForm = ({
               />
             </div>
           )}
-          <div
-            id="announcement"
-            className="visually-hidden"
-            aria-live="polite"
-          ></div>
+          
 
           <input
             id="url-input"

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import Button from "../../common/components/Button";
 import AdvancedScanOptions from "./AdvancedScanOptions";
 import {
@@ -224,17 +224,18 @@ const InitScanForm = ({
         Enter your URL to get started
       </label>
       <div id="url-bar-group">
-       <div id="url-bar">
+        <div id="url-bar">
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-            <fieldset 
+            <fieldset
               style={{
-                border: 'none',
                 padding: 0,
+                border:0,
                 margin: 0,
-                position: 'relative',
-                width: '70px',
-                height: '30px',
-                marginRight: '10px'
+                position: "relative",
+                width: "70px",
+                height: "45px",
+                marginRight: "10px",
+                marginLeft: "-20px",
               }}
             >
               <legend className="visually-hidden">Scan type selection</legend>
@@ -243,12 +244,12 @@ const InitScanForm = ({
                 aria-label="Select scan type"
                 tabIndex="0"
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
+                  if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    const newCheckedState = !isCustomOptionChecked;
-                    setIsCustomOptionChecked(newCheckedState);
-                    setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
-                    if (newCheckedState) {
+                    const newState = !isCustomOptionChecked;
+                    setIsCustomOptionChecked(newState);
+                    setScanUrl(newState ? staticFilePath : staticHttpUrl);
+                    if (newState) {
                       setCachedNonFileScanType(displayScanType);
                       setAdvancedOptions((prevOptions) => ({
                         ...prevOptions,
@@ -261,33 +262,35 @@ const InitScanForm = ({
                       }));
                       setDisplayScanType(cachedNonFileScanType);
                     }
-                    // Announce the new input type
                     setTimeout(() => {
-                      const announcement = newCheckedState ? "File input type selected" : "URL input type selected";
-                      document.getElementById('announcement').textContent = announcement;
+                      const announcement = newState
+                        ? "File input type selected"
+                        : "URL input type selected";
+                      document.getElementById("announcement").textContent =
+                        announcement;
                     }, 100);
                   }
                 }}
                 style={{
-                  position: 'absolute',
+                  position: "absolute",
                   top: 0,
                   left: 0,
-                  width: '100%',
-                  height: '100%',
-                  borderRadius: '15px',
-                  border: '1px solid #b5c5ca',
-                  backgroundColor: 'white',
-                  color: '#333',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: 'pointer',
-                  fontWeight: 'bold',
-                  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-                  transition: 'all 0.3s ease'
+                  width: "100%",
+                  height: "100%",
+                  //borderRadius: "15px",
+                  borderRight: "1px solid #b5c5ca",
+                  //backgroundColor: "transparent",
+                  //color: "#333",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  cursor: "pointer",
+                  fontWeight: "bold",
+                  //boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
+                  //transition: "all 0.3s ease",
                 }}
               >
-                <input 
+                <input
                   type="radio"
                   id="url-radio"
                   name="scan-type"
@@ -301,14 +304,14 @@ const InitScanForm = ({
                       scanType: cachedNonFileScanType,
                     }));
                     setDisplayScanType(cachedNonFileScanType);
-                    // Announce the new input type
                     setTimeout(() => {
-                      document.getElementById('announcement').textContent = "URL input type selected";
+                      document.getElementById("announcement").textContent =
+                        "URL input type selected";
                     }, 100);
                   }}
-                  style={{ position: 'absolute', opacity: 0 }}
+                  style={{ position: "absolute", opacity: 0 }}
                 />
-                <input 
+                <input
                   type="radio"
                   id="file-radio"
                   name="scan-type"
@@ -322,27 +325,35 @@ const InitScanForm = ({
                       ...prevOptions,
                       scanType: scanTypeOptions[3],
                     }));
-                    // Announce the new input type
                     setTimeout(() => {
-                      document.getElementById('announcement').textContent = "File input type selected";
+                      document.getElementById("announcement").textContent =
+                        "File input type selected";
                     }, 100);
                   }}
-                  style={{ position: 'absolute', opacity: 0 }}
+                  style={{ position: "absolute", opacity: 0 }}
                 />
-                <label 
+                <label
                   htmlFor={isCustomOptionChecked ? "url-radio" : "file-radio"}
-                  style={{ cursor: 'pointer', width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                  style={{
+                    cursor: "pointer",
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
                 >
-                  {isCustomOptionChecked ? 'FILE' : 'URL'}
+                  {isCustomOptionChecked ? "FILE" : "URL"}
                 </label>
               </div>
-              <div 
-                id="announcement" 
-                aria-live="polite" 
+              <div
+                id="announcement"
+                aria-live="polite"
                 className="visually-hidden"
               ></div>
             </fieldset>
           )}
+
           <input
             id="url-input"
             type="text"
@@ -353,15 +364,38 @@ const InitScanForm = ({
             }}
           />
           {isCustomOptionChecked && (
-            <div id="file-input-container">
+            <div id="file-input-container" style={{ display: "flex", alignItems: "center" }}>
               <input
                 type="file"
                 id="file-input"
                 accept={allowedFileTypes.join(",")}
-                style={{ display: "none" }}
                 onChange={handleFileChange}
+                aria-label="Choose file"
+                tabIndex="0"
+                style={{
+                  position: "absolute",
+                  width: "1px",
+                  height: "1px",
+                  padding: "0",
+                  margin: "-1px",
+                  overflow: "hidden",
+                  clip: "rect(0,0,0,0)",
+                  whiteSpace: "nowrap",
+                  border: "0",
+                }}
               />
-              <label htmlFor="file-input" id="file-input-label">
+              <label
+                htmlFor="file-input"
+                id="file-input-label"
+                tabIndex="0"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    document.getElementById("file-input").click();
+                  }
+                }}
+                style={{ cursor: "pointer", display: "inline-block" }}
+              >
                 {scanUrl ? scanUrl : "Choose file"}
               </label>
             </div>
@@ -392,6 +426,7 @@ const InitScanForm = ({
                     )}
                   </span>
                 </Button>
+
                 {openPageLimitAdjuster && (
                   <div id="page-limit-adjuster" ref={pageLimitAdjuster}>
                     <input
@@ -407,11 +442,13 @@ const InitScanForm = ({
                         }
                       }}
                     />
+
                     <label htmlFor="page-limit-input">{pageWord}</label>
                   </div>
                 )}
               </div>
             )}
+
           <Button
             type="btn-primary"
             className="scan-btn"
@@ -425,6 +462,7 @@ const InitScanForm = ({
             )}
           </Button>
         </div>
+
         {prevUrlErrorMessage && (
           <span id="url-error-message" className="error-text">
             {prevUrlErrorMessage}
@@ -447,6 +485,7 @@ const InitScanForm = ({
         deviceOptions={deviceOptions}
         advancedOptions={{
           ...advancedOptions,
+
           scanType: isCustomOptionChecked
             ? displayScanType
             : advancedOptions.scanType,
@@ -454,17 +493,24 @@ const InitScanForm = ({
         setAdvancedOptions={(newOptions) => {
           if (!isCustomOptionChecked) {
             setAdvancedOptions(newOptions);
+
             setDisplayScanType(newOptions.scanType);
+
             setCachedNonFileScanType(newOptions.scanType);
           } else {
             setDisplayScanType(newOptions.scanType);
+
             setCachedNonFileScanType(newOptions.scanType);
+
             setAdvancedOptions({
               ...advancedOptions,
+
               ...newOptions,
+
               scanType: scanTypeOptions[3],
             });
           }
+
           setAllowedFileTypes(getAllowedFileTypes(newOptions.scanType));
         }}
         scanButtonIsClicked={scanButtonIsClicked}

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -39,7 +39,9 @@ const InitScanForm = ({
   const [staticHttpUrl, setStaticHttpUrl] = useState("https://");
   const [staticFilePath, setStaticFilePath] = useState("file:///");
   const [cachedNonFileScanType, setCachedNonFileScanType] = useState(() => {
-    return sessionStorage.getItem("cachedNonFileScanType") || scanTypeOptions[0];
+    return (
+      sessionStorage.getItem("cachedNonFileScanType") || scanTypeOptions[0]
+    );
   });
   const [displayScanType, setDisplayScanType] = useState(scanTypeOptions[0]);
   const [allowedFileTypes, setAllowedFileTypes] = useState([]);
@@ -101,10 +103,14 @@ const InitScanForm = ({
 
     setAdvancedOptions((prevOptions) => ({
       ...prevOptions,
-      scanType: wasLocalFileScan ? cachedNonFileScanType : (cachedScanType || prevOptions.scanType),
+      scanType: wasLocalFileScan
+        ? cachedNonFileScanType
+        : cachedScanType || prevOptions.scanType,
     }));
 
-    setAllowedFileTypes(getAllowedFileTypes(cachedScanType || scanTypeOptions[0]));
+    setAllowedFileTypes(
+      getAllowedFileTypes(cachedScanType || scanTypeOptions[0])
+    );
   }, []);
 
   useEffect(() => {
@@ -114,8 +120,14 @@ const InitScanForm = ({
       setStaticHttpUrl(scanUrl);
     }
 
-    sessionStorage.setItem("isCustomOptionChecked", JSON.stringify(isCustomOptionChecked));
-    sessionStorage.setItem("scanType", isCustomOptionChecked ? scanTypeOptions[3] : displayScanType);
+    sessionStorage.setItem(
+      "isCustomOptionChecked",
+      JSON.stringify(isCustomOptionChecked)
+    );
+    sessionStorage.setItem(
+      "scanType",
+      isCustomOptionChecked ? scanTypeOptions[3] : displayScanType
+    );
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
     sessionStorage.setItem("cachedNonFileScanType", cachedNonFileScanType);
   }, [isCustomOptionChecked, scanUrl, displayScanType, cachedNonFileScanType]);
@@ -148,9 +160,13 @@ const InitScanForm = ({
 
   const handleScanButtonClicked = () => {
     if (isCustomOptionChecked) {
-      const fileExtension = '.' + scanUrl.split('.').pop().toLowerCase();
+      const fileExtension = "." + scanUrl.split(".").pop().toLowerCase();
       if (!allowedFileTypes.includes(fileExtension)) {
-        alert(`Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(", ")}`);
+        alert(
+          `Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(
+            ", "
+          )}`
+        );
         return;
       }
     }
@@ -167,7 +183,12 @@ const InitScanForm = ({
 
     if (isCustomOptionChecked) {
       setStaticFilePath(scanUrl);
-      startScan({ file: selectedFile, scanUrl, ...advancedOptions, scanType: scanTypeOptions[3] });
+      startScan({
+        file: selectedFile,
+        scanUrl,
+        ...advancedOptions,
+        scanType: scanTypeOptions[3],
+      });
     } else {
       setStaticHttpUrl(scanUrl);
       startScan({ scanUrl: scanUrl.trim(), pageLimit, ...advancedOptions });
@@ -177,14 +198,21 @@ const InitScanForm = ({
   const handleFileChange = (e) => {
     const file = e.target.files[0];
     if (file) {
-      const fileExtension = '.' + file.name.split(".").pop().toLowerCase();
-      if (allowedFileTypes.includes(fileExtension) || (fileExtension === '.txt' && allowedFileTypes.includes('.txt'))) {
+      const fileExtension = "." + file.name.split(".").pop().toLowerCase();
+      if (
+        allowedFileTypes.includes(fileExtension) ||
+        (fileExtension === ".txt" && allowedFileTypes.includes(".txt"))
+      ) {
         const readablePath = convertToReadablePath(file.path);
         setScanUrl(readablePath);
         setStaticFilePath(readablePath);
         setSelectedFile(file);
       } else {
-        alert(`Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(", ")}`);
+        alert(
+          `Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(
+            ", "
+          )}`
+        );
         e.target.value = "";
       }
     }
@@ -323,11 +351,23 @@ const InitScanForm = ({
 
       <AdvancedScanOptions
         isProxy={isProxy}
-        scanTypeOptions={isCustomOptionChecked ? scanTypeOptions.filter(option => option !== scanTypeOptions[2] && option !== scanTypeOptions[3]) : scanTypeOptions.filter(option => option !== scanTypeOptions[3])}
+        scanTypeOptions={
+          isCustomOptionChecked
+            ? scanTypeOptions.filter(
+                (option) =>
+                  option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
+              )
+            : scanTypeOptions.filter((option) => option !== scanTypeOptions[3])
+        }
         fileTypesOptions={fileTypesOptions}
         viewportOptions={viewportOptions}
         deviceOptions={deviceOptions}
-        advancedOptions={{...advancedOptions, scanType: isCustomOptionChecked ? displayScanType : advancedOptions.scanType}}
+        advancedOptions={{
+          ...advancedOptions,
+          scanType: isCustomOptionChecked
+            ? displayScanType
+            : advancedOptions.scanType,
+        }}
         setAdvancedOptions={(newOptions) => {
           if (!isCustomOptionChecked) {
             setAdvancedOptions(newOptions);
@@ -336,10 +376,16 @@ const InitScanForm = ({
           } else {
             setDisplayScanType(newOptions.scanType);
             setCachedNonFileScanType(newOptions.scanType);
+            setAdvancedOptions({
+              ...advancedOptions,
+              ...newOptions,
+              scanType: scanTypeOptions[3],
+            });
           }
           setAllowedFileTypes(getAllowedFileTypes(newOptions.scanType));
         }}
         scanButtonIsClicked={scanButtonIsClicked}
+        isCustomOptionChecked={isCustomOptionChecked}
       />
     </div>
   );

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -147,6 +147,14 @@ const InitScanForm = ({
   };
 
   const handleScanButtonClicked = () => {
+    if (isCustomOptionChecked) {
+      const fileExtension = '.' + scanUrl.split('.').pop().toLowerCase();
+      if (!allowedFileTypes.includes(fileExtension)) {
+        alert(`Invalid file format. Please choose a file with one of these extensions: ${allowedFileTypes.join(", ")}`);
+        return;
+      }
+    }
+
     if (isProxy && advancedOptions.viewport === viewportTypes.mobile) {
       advancedOptions.viewport = viewportTypes.custom;
       advancedOptions.viewportWidth = 414;

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -65,20 +65,23 @@ const InitScanForm = ({
   useEffect(() => {
     const cachedScanUrl = sessionStorage.getItem("scanUrl");
     const cacheScanUrlJson = cachedScanUrl ? JSON.parse(cachedScanUrl) : null;
-    if (cachedScanUrl) {
-      setScanUrl(JSON.parse(cachedScanUrl));
-    } else if (isCustomOptionChecked) {
+    const cachedScanType = sessionStorage.getItem("scanType");
+    const wasLocalFileScan = cachedScanType === scanTypeOptions[3];
+  
+    if (isCustomOptionChecked) {
       setScanUrl("file:///");
+    } else if (cachedScanUrl && !wasLocalFileScan) {
+      setScanUrl(JSON.parse(cachedScanUrl));
     } else {
       setScanUrl("https://");
     }
-
+  
     setAdvancedOptions((prevOptions) => ({
       ...prevOptions,
       scanType: isCustomOptionChecked ? scanTypeOptions[3] : scanTypeOptions[0],
     }));
+    sessionStorage.setItem("scanType", isCustomOptionChecked ? scanTypeOptions[3] : scanTypeOptions[0]);
   }, [isCustomOptionChecked]);
-
   useEffect(() => {
     const urlBarElem = document.getElementById("url-bar");
     const urlBarInputList = urlBarElem.querySelectorAll("input, button");
@@ -111,8 +114,7 @@ const InitScanForm = ({
     sessionStorage.setItem("pageLimit", JSON.stringify(pageLimit));
     sessionStorage.setItem("advancedOptions", JSON.stringify(advancedOptions));
     sessionStorage.setItem("scanUrl", JSON.stringify(scanUrl));
-    if (
-      advancedOptions.scanType === scanTypeOptions[3] &&
+    if ( 
       isCustomOptionChecked &&
       selectedFile
     ) {

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -181,39 +181,41 @@ const InitScanForm = ({
       </label>
       <div id="url-bar-group">
         <div id="url-bar">
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              marginRight: "10px",
-            }}
-          >
-            <input
-              type="checkbox"
-              id="custom-checkbox"
-              style={{ marginRight: "5px" }}
-              checked={isCustomOptionChecked}
-              onChange={(e) => {
-                const newCheckedState = e.target.checked;
-                setIsCustomOptionChecked(newCheckedState);
-                setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
-                if (newCheckedState) {
-                  setCachedNonFileScanType(advancedOptions.scanType);
-                  setAdvancedOptions((prevOptions) => ({
-                    ...prevOptions,
-                    scanType: scanTypeOptions[3],
-                  }));
-                } else {
-                  setAdvancedOptions((prevOptions) => ({
-                    ...prevOptions,
-                    scanType: cachedNonFileScanType,
-                  }));
-                  setDisplayScanType(cachedNonFileScanType);
-                }
+          {advancedOptions.scanType !== scanTypeOptions[2] && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginRight: "10px",
               }}
-            />
-            <label htmlFor="custom-checkbox">File</label>
-          </div>
+            >
+              <input
+                type="checkbox"
+                id="custom-checkbox"
+                style={{ marginRight: "5px" }}
+                checked={isCustomOptionChecked}
+                onChange={(e) => {
+                  const newCheckedState = e.target.checked;
+                  setIsCustomOptionChecked(newCheckedState);
+                  setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
+                  if (newCheckedState) {
+                    setCachedNonFileScanType(advancedOptions.scanType);
+                    setAdvancedOptions((prevOptions) => ({
+                      ...prevOptions,
+                      scanType: scanTypeOptions[3],
+                    }));
+                  } else {
+                    setAdvancedOptions((prevOptions) => ({
+                      ...prevOptions,
+                      scanType: cachedNonFileScanType,
+                    }));
+                    setDisplayScanType(cachedNonFileScanType);
+                  }
+                }}
+              />
+              <label htmlFor="custom-checkbox">File</label>
+            </div>
+          )}
           <input
             id="url-input"
             type="text"
@@ -305,7 +307,7 @@ const InitScanForm = ({
 
       <AdvancedScanOptions
         isProxy={isProxy}
-        scanTypeOptions={scanTypeOptions}
+        scanTypeOptions={isCustomOptionChecked ? scanTypeOptions.filter(option => option !== scanTypeOptions[2] && option !== scanTypeOptions[3]) : scanTypeOptions.filter(option => option !== scanTypeOptions[3])}
         fileTypesOptions={fileTypesOptions}
         viewportOptions={viewportOptions}
         deviceOptions={deviceOptions}

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -15,13 +15,13 @@ import LoadingSpinner from "../../common/components/LoadingSpinner";
 
 function convertToReadablePath(path) {
   // Normalize the path to use forward slashes
-  let readable = path.replace(/\\/g, '/');
+  let readable = path.replace(/\\/g, "/");
   // Handle Windows drive letters
   if (/^[a-zA-Z]:/.test(readable)) {
-    readable = readable.replace(/^([a-zA-Z]):/, '/$1:');
+    readable = readable.replace(/^([a-zA-Z]):/, "/$1:");
   }
   // Ensure there are exactly three slashes after 'file:'
-  return `file:///${readable.replace(/^\/+/, '')}`;
+  return `file:///${readable.replace(/^\/+/, "")}`;
 }
 
 const InitScanForm = ({
@@ -60,7 +60,7 @@ const InitScanForm = ({
       : getDefaultAdvancedOptions(isProxy);
   });
 
-  const [scanUrl, setScanUrl] = useState("") ;
+  const [scanUrl, setScanUrl] = useState("");
 
   useEffect(() => {
     const cachedScanUrl = sessionStorage.getItem("scanUrl");
@@ -112,12 +112,30 @@ const InitScanForm = ({
     }
   };
 
-  const handleFileChange = async (e) => {
+  const handleFileChange =(e) => {
     const file = e.target.files[0];
     if (file) {
-      const readablePath = convertToReadablePath(file.path);
-      setScanUrl(readablePath);
-      setSelectedFile(file);
+      const fileExtension = file.name.split(".").pop().toLowerCase();
+      //Additional validation as alot of different files are regarded as txt files
+      const allowedExtensions = [
+        "dhtml",
+        "html",
+        "htm",
+        "txt",
+        "shtml",
+        "xml",
+        "xhtml",
+        "pdf",
+      ];
+
+      if (allowedExtensions.includes(fileExtension)) {
+        const readablePath = convertToReadablePath(file.path);
+        setScanUrl(readablePath);
+        setSelectedFile(file);
+      } else {
+        alert("Invalid file format. Please choose a valid file.");
+        e.target.value = ""; // Reset the input
+      }
     }
   };
 
@@ -145,7 +163,8 @@ const InitScanForm = ({
               <input
                 type="file"
                 id="file-input"
-                accept=".xml"
+                //Alot of file extensions are treated as .txt so we need to handle it after the file is selected
+                accept=".dhtml,.html,.htm,.shtml,.xml,.xhtml,.pdf,text/plain"
                 style={{ display: "none" }}
                 onChange={handleFileChange}
               />

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -224,41 +224,124 @@ const InitScanForm = ({
         Enter your URL to get started
       </label>
       <div id="url-bar-group">
-        <div id="url-bar">
+       <div id="url-bar">
           {advancedOptions.scanType !== scanTypeOptions[2] && (
-            <div
+            <fieldset 
               style={{
-                display: "flex",
-                alignItems: "center",
-                marginRight: "10px",
+                border: 'none',
+                padding: 0,
+                margin: 0,
+                position: 'relative',
+                width: '70px',
+                height: '30px',
+                marginRight: '10px'
               }}
             >
-              <input
-                type="checkbox"
-                id="custom-checkbox"
-                style={{ marginRight: "5px" }}
-                checked={isCustomOptionChecked}
-                onChange={(e) => {
-                  const newCheckedState = e.target.checked;
-                  setIsCustomOptionChecked(newCheckedState);
-                  setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
-                  if (newCheckedState) {
-                    setCachedNonFileScanType(displayScanType);
-                    setAdvancedOptions((prevOptions) => ({
-                      ...prevOptions,
-                      scanType: scanTypeOptions[3],
-                    }));
-                  } else {
+              <legend className="visually-hidden">Scan type selection</legend>
+              <div
+                role="radiogroup"
+                aria-label="Select scan type"
+                tabIndex="0"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    const newCheckedState = !isCustomOptionChecked;
+                    setIsCustomOptionChecked(newCheckedState);
+                    setScanUrl(newCheckedState ? staticFilePath : staticHttpUrl);
+                    if (newCheckedState) {
+                      setCachedNonFileScanType(displayScanType);
+                      setAdvancedOptions((prevOptions) => ({
+                        ...prevOptions,
+                        scanType: scanTypeOptions[3],
+                      }));
+                    } else {
+                      setAdvancedOptions((prevOptions) => ({
+                        ...prevOptions,
+                        scanType: cachedNonFileScanType,
+                      }));
+                      setDisplayScanType(cachedNonFileScanType);
+                    }
+                    // Announce the new input type
+                    setTimeout(() => {
+                      const announcement = newCheckedState ? "File input type selected" : "URL input type selected";
+                      document.getElementById('announcement').textContent = announcement;
+                    }, 100);
+                  }
+                }}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                  borderRadius: '15px',
+                  border: '1px solid #b5c5ca',
+                  backgroundColor: 'white',
+                  color: '#333',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  fontWeight: 'bold',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                  transition: 'all 0.3s ease'
+                }}
+              >
+                <input 
+                  type="radio"
+                  id="url-radio"
+                  name="scan-type"
+                  value="url"
+                  checked={!isCustomOptionChecked}
+                  onChange={() => {
+                    setIsCustomOptionChecked(false);
+                    setScanUrl(staticHttpUrl);
                     setAdvancedOptions((prevOptions) => ({
                       ...prevOptions,
                       scanType: cachedNonFileScanType,
                     }));
                     setDisplayScanType(cachedNonFileScanType);
-                  }
-                }}
-              />
-              <label htmlFor="custom-checkbox">File</label>
-            </div>
+                    // Announce the new input type
+                    setTimeout(() => {
+                      document.getElementById('announcement').textContent = "URL input type selected";
+                    }, 100);
+                  }}
+                  style={{ position: 'absolute', opacity: 0 }}
+                />
+                <input 
+                  type="radio"
+                  id="file-radio"
+                  name="scan-type"
+                  value="file"
+                  checked={isCustomOptionChecked}
+                  onChange={() => {
+                    setIsCustomOptionChecked(true);
+                    setScanUrl(staticFilePath);
+                    setCachedNonFileScanType(displayScanType);
+                    setAdvancedOptions((prevOptions) => ({
+                      ...prevOptions,
+                      scanType: scanTypeOptions[3],
+                    }));
+                    // Announce the new input type
+                    setTimeout(() => {
+                      document.getElementById('announcement').textContent = "File input type selected";
+                    }, 100);
+                  }}
+                  style={{ position: 'absolute', opacity: 0 }}
+                />
+                <label 
+                  htmlFor={isCustomOptionChecked ? "url-radio" : "file-radio"}
+                  style={{ cursor: 'pointer', width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                >
+                  {isCustomOptionChecked ? 'FILE' : 'URL'}
+                </label>
+              </div>
+              <div 
+                id="announcement" 
+                aria-live="polite" 
+                className="visually-hidden"
+              ></div>
+            </fieldset>
           )}
           <input
             id="url-input"

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -89,7 +89,7 @@ const InitScanForm = ({
 
     if (wasLocalFileScan) {
       setIsCustomOptionChecked(true);
-      const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "file:///";
+      const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "Choose file...";
       setScanUrl(newScanUrl);
       setStaticFilePath(newScanUrl);
       setStaticHttpUrl("https://");
@@ -99,7 +99,7 @@ const InitScanForm = ({
       const newScanUrl = cachedScanUrl ? JSON.parse(cachedScanUrl) : "https://";
       setScanUrl(newScanUrl);
       setStaticHttpUrl(newScanUrl);
-      setStaticFilePath("file:///");
+      setStaticFilePath("Choose file...");
       setCachedNonFileScanType(cachedScanType || scanTypeOptions[0]);
       setDisplayScanType(cachedScanType || scanTypeOptions[0]);
     }
@@ -258,7 +258,8 @@ const InitScanForm = ({
   return (
     <div id="init-scan-form">
       <label htmlFor="url-input" id="url-bar-label">
-        Enter your{" "}
+        {isCustomOptionChecked ? "Select" : "Enter"} {" "}
+        your{" "}
         <strong>{isCustomOptionChecked ? "local file" : "URL"} </strong>
         to get started
       </label>
@@ -280,7 +281,7 @@ const InitScanForm = ({
                 {isCustomOptionChecked ? "FILE" : "URL"}
               </button>
               <ToolTip
-                description={`Switch to ${
+                description={`Toggle to ${
                   isCustomOptionChecked ? "URL" : "file"
                 } input`}
                 id="toggle-url-file-tooltip"

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -191,7 +191,7 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
     } else if (scanDetails.scanType === "Local file") {
       if (!isValidFilepath(scanDetails.scanUrl)) {
         setScanButtonIsClicked(false);
-        setPrevUrlErrorMessage("Invalid FilePath. Please type in file:/// format.");
+        setPrevUrlErrorMessage("File is not a local html or sitemap file.");
         return;
       }
     } else if (!isValidHttpUrl(scanDetails.scanUrl)) {

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -265,6 +265,9 @@ const HomePage = ({ isProxy, appVersionInfo, setCompletedScanId }) => {
           case cliErrorTypes.notASitemap:
             errorMessageToShow = "Invalid sitemap.";
             break;
+          case cliErrorTypes.notALocalFile:
+            errorMessageToShow = "File is not a local html or sitemap file.";
+            break;
           case cliErrorTypes.browserError:
             navigate("/error", {
               state: { errorState: errorStates.browserError, timeOfScan },

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -94,7 +94,7 @@ export const getDefaultAdvancedOptions = (isProxy) => {
 };
 
 // exit codes returned by Purple A11y cli when there is an error with the URL provided
-export const cliErrorCodes = new Set([11, 12, 13, 14, 15, 16, 17]);
+export const cliErrorCodes = new Set([11, 12, 13, 14, 15, 16, 17, 19]);
 export const cliErrorTypes = {
   invalidUrl: 11,
   cannotBeResolved: 12,
@@ -103,6 +103,7 @@ export const cliErrorTypes = {
   notASitemap: 15,
   unauthorisedBasicAuth: 16,
   browserError: 17,
+  notALocalFile: 19, 
 };
 
 export const errorStates = {


### PR DESCRIPTION
This PR makes the changes necessary to change localFileScan from a scan mode to an input scan type.

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [] I've tested existing features (website scan, sitemap, custom flow)
- [] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
