### PR TITLE
bugfix: remove logic forcing 414px for custom width on mobile

### DIFF
--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -170,11 +170,6 @@ const InitScanForm = ({
       }
     }
 
-    if (advancedOptions.viewport === viewportTypes.mobile) {
-      advancedOptions.viewport = viewportTypes.custom
-      advancedOptions.viewportWidth = 414
-    }
-
     setScanButtonIsClicked(true)
     sessionStorage.setItem('pageLimit', JSON.stringify(pageLimit))
     sessionStorage.setItem('advancedOptions', JSON.stringify(advancedOptions))


### PR DESCRIPTION
**Issue Fixed:** Mobile viewport was automatically setting width to 414px when starting a scan.

**Solution:** Removed the logic in `src/MainWindow/HomePage/InitScanForm.jsx:173-176` that was automatically converting the mobile viewport to custom viewport with 414px width.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1 reviewer
- [x] I've tested existing features (website scan, sitemap, custom flow)
- [x] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
