### PR TITLE
Spawn installer without powershell on Windows

### DIFF
--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -218,36 +218,23 @@ const downloadAndUnzipFrontendMac = async (tag = undefined) => {
 };
 
 /**
- * Spawn a PowerShell process to launch the InnoSetup installer executable, which contains the frontend and backend
+ * Spawn a process to launch the InnoSetup installer executable, which contains the frontend and backend
  * upon confirmation from the user, the installer will be launched & Electron will exit
  * @returns {Promise<boolean>} true if the installer executable was launched successfully, false otherwise
  */
 const spawnScriptToLaunchInstaller = () => {
-
-  const shellScript = `Start-Process -FilePath "${installerExePath}"`;
-
-  return new Promise((resolve, reject) => {
-    const ps = spawn("powershell.exe", ["-Command", shellScript]);
-    currentChildProcess = ps;
-
-    ps.stdout.on("data", (data) => {
-      console.log(data.toString());
+  try {
+    // Launch the installer executable directly without waiting for it to finish
+    const child = spawn(installerExePath, [], {
+      detached: true,
+      stdio: "ignore"
     });
-
-    ps.stderr.on("data", (data) => {
-      currentChildProcess = null;
-      console.error(data.toString());
-    });
-
-    ps.on("exit", (code) => {
-      currentChildProcess = null;
-      if (code === 0) {
-        resolve(true);
-      } else {
-        resolve(false);
-      }
-    });
-  });
+    child.unref();
+    return true;
+  } catch (e) {
+    consoleLogger.error(`Failed to launch installer: ${e.message}`);
+    return false;
+  }
 };
 
 


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- Resolve Crowdstrike Falcon Agent false-positive identification of malicious PowerShell command when Oobee Desktop installer is executed from within Oobee Desktop update process on Windows.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
