### PR TITLE
Fix missing Inno Setup ISCC binary in build step

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -24,10 +24,11 @@ jobs:
           mkdir nodejs-win && tar -xzf nodejs-win.zip -C nodejs-win --strip-components=1 && rm ./nodejs-win.zip
         working-directory: ${{github.workspace}}
 
-      - name: Download Inno Setup
+      - name: Download and Install Inno Setup
         shell: pwsh
         run: |
           Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "${{github.workspace}}\is.exe" 
+          Start-Process -FilePath "${{github.workspace}}\is.exe" -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-" -Wait
           $env:path = "$env:path" + ";${env:programfiles(x86)}\Inno Setup 6"
 
       - name: Install Node Modules and Build for Windows

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "${{github.workspace}}\is.exe" 
           Start-Process -FilePath "${{github.workspace}}\is.exe" -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/SP-" -Wait
-          $env:path = "$env:path" + ";${env:programfiles(x86)}\Inno Setup 6"
-
+          echo "${env:programfiles(x86)}\Inno Setup 6" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          
       - name: Install Node Modules and Build for Windows
         run: |
           $env:Path = "${{github.workspace}}\nodejs-win;${{github.workspace}}\oobee-desktop\node_modules\.bin;$env:Path;";


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
