### PR TITLE
Fix re-scan of same sitemap options causes invalid sitemap error

### DIFF
--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -158,9 +158,6 @@ const InitScanForm = ({
   }
 
   const handleScanButtonClicked = () => {
-    // Capture the current scan type to ensure consistency
-    const currentScanType = isFileOptionChecked ? displayScanType : advancedOptions.scanType
-
     if (isFileOptionChecked) {
       const fileExtension = '.' + scanUrl.split('.').pop().toLowerCase()
       if (!allowedFileTypes.includes(fileExtension)) {
@@ -180,14 +177,17 @@ const InitScanForm = ({
 
     if (isFileOptionChecked) {
       setStaticFilePath(scanUrl)
-      startScan({
+      const scanParams = {
         file: selectedFile,
         scanUrl,
-        scanType: scanTypeOptions[3],
-        // if sitemap scan, then pageLimit is set
-        ...(currentScanType === scanTypeOptions[1]) && { pageLimit: pageLimit },
         ...advancedOptions,
-      })
+        scanType: scanTypeOptions[3], // Send 'Local file' to CLI
+      }
+      // Only include pageLimit for sitemap scans
+      if (displayScanType === scanTypeOptions[1]) {
+        scanParams.pageLimit = pageLimit
+      }
+      startScan(scanParams)
     } else {
       setStaticHttpUrl(scanUrl)
       startScan({ scanUrl: scanUrl.trim(), pageLimit, ...advancedOptions })
@@ -284,8 +284,9 @@ const InitScanForm = ({
                 {isFileOptionChecked ? 'FILE' : 'URL'}
               </button>
               <ToolTip
-                description={`Toggle to ${isFileOptionChecked ? 'URL' : 'file'
-                  } input`}
+                description={`Toggle to ${
+                  isFileOptionChecked ? 'URL' : 'file'
+                } input`}
                 id="toggle-url-file-tooltip"
                 showToolTip={showToggleUrlFileTooltip}
               />
@@ -315,11 +316,8 @@ const InitScanForm = ({
             </div>
           )}
 
-          {
-            (
-              (!isFileOptionChecked && advancedOptions.scanType !== scanTypeOptions[2]) ||
-              (isFileOptionChecked && displayScanType === scanTypeOptions[1])
-            ) && (
+          {displayScanType !== scanTypeOptions[2] &&
+            !(isFileOptionChecked && displayScanType === scanTypeOptions[0]) && (
               <div>
                 <Button
                   type="btn-link"
@@ -389,9 +387,9 @@ const InitScanForm = ({
         scanTypeOptions={
           isFileOptionChecked
             ? scanTypeOptions.filter(
-              (option) =>
-                option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
-            )
+                (option) =>
+                  option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
+              )
             : scanTypeOptions.filter((option) => option !== scanTypeOptions[3])
         }
         fileTypesOptions={fileTypesOptions}

--- a/src/services.js
+++ b/src/services.js
@@ -24,6 +24,12 @@ const validateUrlConnectivity = async (scanDetails) => {
     viewportWidth,
     browser,
     fileTypes: selectedFileTypes,
+    customChecks,
+    wcagAaa,
+    maxConcurrency,
+    includeScreenshots,
+    includeSubdomains,
+    followRobots,
   } = scanDetails
 
   currentScanUrl = scanUrl
@@ -34,6 +40,12 @@ const validateUrlConnectivity = async (scanDetails) => {
     url: scanUrl,
     browser: browser,
     fileTypes: fileTypes[selectedFileTypes],
+    customChecks: customChecks,
+    wcagAaa: wcagAaa,
+    maxConcurrency: maxConcurrency,
+    includeScreenshots,
+    includeSubdomains,
+    followRobots,
   }
 
   if (viewport === viewportTypes.mobile) {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
