### PR TITLE
Remove prompt for custom flow label in desktop app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19704,9 +19704,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "webpack-dev-server": "^5.2.2",
     "tmp": "^0.2.5",
     "brace-expansion": "^1.1.12",
-    "debug": "^4.4.3"
+    "debug": "^4.4.3",
+    "node-forge": "^1.3.2"
   },
   "description": "Oobee Desktop"
 }

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -28,9 +28,6 @@ contextBridge.exposeInMainWorld("services", {
     await ipcRenderer.invoke("abortScan");
   },
 
-  generateReport: (customFormLabel, scanId) => {
-    ipcRenderer.send("generateReport", customFormLabel, scanId);
-  },
   openReport: (scanId) => {
     ipcRenderer.send("openReport", scanId);
   },

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -9,7 +9,6 @@ const {
   createCipheriv,
   createDecipheriv,
 } = require('crypto')
-const pako = require('pako')
 const {
   enginePath,
   appPath,
@@ -433,71 +432,6 @@ const decryptGeneratedScript = (generatedScript, encryptionParams) => {
   fs.writeFileSync(generatedScript, decrypted)
 }
 
-const injectLabelIntoFolderName = (customFlowLabel, scanId) => {
-  const currentFolderNameList = scanHistory[scanId].split('_')
-  const currentResultsFolderPath = getResultsFolderPath(scanId)
-  const newFolderNameList = [
-    ...currentFolderNameList.slice(0, 2),
-    customFlowLabel,
-    ...currentFolderNameList.slice(2),
-  ]
-  const newFolderName = newFolderNameList.toString().replaceAll(',', '_')
-  scanHistory[scanId] = newFolderName
-  const newResultsFolderPath = getResultsFolderPath(scanId)
-  fs.renameSync(currentResultsFolderPath, newResultsFolderPath)
-}
-const escapeHTMLEntitiesInLabel = (customFlowLabel) => {
-  return customFlowLabel.replaceAll(/&/g, '&amp;')
-}
-const generateReport = (customFlowLabel, scanId) => {
-  injectLabelIntoFolderName(customFlowLabel, scanId);
-  const reportPath = getReportPath(scanId);
-  const escapedCustomFlowLabel = escapeHTMLEntitiesInLabel(customFlowLabel);
-
-  // edit custom flow label in the base 64 encoded scanData in report
-  const data = fs.readFileSync(reportPath, { encoding: 'utf-8' });
-  const scanDataEncoded = data.match(/scanDataPromise\s*=\s*\(async\s*\(\)\s*=>\s*{[^]*?decodeUnzipParse\('([^']+)'\)/)[1];
-  const scanDataDecodedJson = base64Decode(scanDataEncoded);
-  
-  scanDataDecodedJson.customFlowLabel = escapedCustomFlowLabel;
-  const scanDataEncodedWithNewLabel = base64EncodeGzip(scanDataDecodedJson);
-  const result = data.replaceAll(scanDataEncoded, scanDataEncodedWithNewLabel); // find the encoded part, decode it and change the label then put back
-  fs.writeFileSync(reportPath, result, { encoding: 'utf-8' });
-
-}
-
-const base64Decode = (data) => {
-  // Remove invalid Base64 characters
-  const dataWithValidBase64Char = data.replace(/[^A-Za-z0-9+/=]/g, '');
-
-  // Decode Base64 to a Uint8Array (binary data)
-  const compressedBytes = Uint8Array.from(atob(dataWithValidBase64Char), (c) =>
-    c.charCodeAt(0)
-  );
-
-  // Decompress the binary data using pako.inflate
-  const decompressedBytes = pako.inflate(compressedBytes);
-
-  // Decode the decompressed bytes into a UTF-8 string
-  const jsonString = new TextDecoder().decode(decompressedBytes);
-
-  // Parse and return the JSON object
-  return JSON.parse(jsonString);
-};
-
-
-function base64EncodeGzip(data) {
-  // 1) Stringify JSON
-  const jsonString = JSON.stringify(data);
-  // 2) GZIP compress
-  const compressedBytes = pako.gzip(jsonString);
-  // 3) Convert to base64
-  const base64String = btoa(
-    String.fromCharCode(...compressedBytes)
-  );
-  return base64String;
-}
-
 const getReportPath = (scanId) => {
   const resultsFolderPath = getResultsFolderPath(scanId)
   if (scanHistory[scanId]) {
@@ -653,10 +587,6 @@ const init = (scanEvent) => {
 
   ipcMain.handle('abortScan', async (_event) => {
     setKillChildProcessSignal()
-  })
-
-  ipcMain.on('generateReport', (_event, customFlowLabel, scanId) => {
-    return generateReport(customFlowLabel, scanId)
   })
 
   ipcMain.on('openReport', async (_event, scanId) => {

--- a/src/MainWindow/CustomFlow/index.jsx
+++ b/src/MainWindow/CustomFlow/index.jsx
@@ -1,83 +1,24 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import services from "../../services";
 import './CustomFlow.scss';
-import labelIcon from "../../assets/label-icon.svg";
-import CustomFlowDisplay from "./components/CustomFlowDisplay";
-
 
 const CustomFlowPage = ({ completedScanId, setCompletedScanId }) => {
     const { state }= useLocation(); 
     const navigate = useNavigate();
     const [scanDetails, setScanDetails] = useState(null);
-    const [customFlowLabel, setCustomFlowLabel] = useState('');
-    const [inputErrorMessage, setInputErrorMessage] = useState(null);
 
     useEffect(() => {
         if (state?.scanDetails) {
           setScanDetails(state.scanDetails);
+          window.localStorage.setItem("latestCustomFlowScanDetails", JSON.stringify(state.scanDetails));
+          navigate("/result");
         }
-    }, [])
-
-    const validateLabel = () => {
-      const {isValid, errorMessage} = services.isValidCustomFlowLabel(customFlowLabel);
-      if (!isValid) {
-        setInputErrorMessage(errorMessage);
-        return false; 
-      } 
-      return true;
-    }
-
-    const onHandleLabelChange = (e) => {
-      setInputErrorMessage(null);
-      setCustomFlowLabel(e.target.value);
-    }
-
-    const generateReport = (e) => {
-      e.preventDefault();
-
-      const validated = validateLabel();
-      if (validated) {
-        window.services.generateReport(customFlowLabel.trim(), completedScanId); 
-        window.localStorage.setItem("latestCustomFlowScanDetails", JSON.stringify(scanDetails));
-        navigate("/result", {state: {customFlowLabel: customFlowLabel }});  
-      }
-      return;
-    }
-
-    const currentDisplay = () => {
-        return (
-          <>
-            <CustomFlowDisplay
-              icon={labelIcon}
-              title={"Label"}
-              url={scanDetails.scanUrl}
-              description={"Assign a recognisable label to this custom flow for convenient reference in the report."}
-            />
-            <label className="custom-label-form-label" for="custom-label-input">Custom Flow Label</label>
-            <form id="custom-label-form" onSubmit={(e) => {generateReport(e)}}>
-              <input 
-                id="custom-label-input" 
-                type="text" 
-                onChange={onHandleLabelChange} 
-                onBlur={validateLabel}
-                aria-describedby="invalid-label-error"
-                aria-invalid={!!inputErrorMessage}
-              />
-              <div className="error-text" id="invalid-label-error">{inputErrorMessage}</div>
-              <button type="submit" className={`btn-primary custom-label-button`} disabled={inputErrorMessage}>Generate Report</button>
-            </form>
-          </>
-        )
-    }
-
+    }, [state, navigate])
 
     return (
       <div id="custom-flow">
         { scanDetails && 
-          <>
-            <div className="custom-flow-content">{currentDisplay()}</div>
-          </>
+          <div className="custom-flow-content">Loading results...</div>
         }
       </div>
     )


### PR DESCRIPTION
Remove the screen and injection of text in report.html since it is processed by Oobee CLI in custom flow (chrome browser)


This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
