### PR TITLE
Cleanly unzip Backend folder on MacOS prevent node_modules errors

### DIFF
--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -98,7 +98,7 @@ const hashPrepackage = async (prepackagePath) => {
 
 // unzip backend zip for mac
 const unzipBackendAndCleanUp = async (zipPath) => {
-  let unzipCommand = `mkdir -p '${backendPath}' && tar -xf '${zipPath}' -C '${backendPath}' &&
+  let unzipCommand = `rm -rf '${backendPath}' && mkdir -p '${backendPath}' && tar -xf '${zipPath}' -C '${backendPath}' &&
     cd '${backendPath}' &&
     './a11y_shell.sh' echo "Initialise"
     `;


### PR DESCRIPTION
tar the backend is not sufficient, resulting in potential mix of old and new files in Oobee Backend, which might result in application errors

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [x] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
