### PR TITLE
feat: make intelligent crawler the default scan type

### DIFF
--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -81,7 +81,7 @@ const getScanOptions = (details) => {
     options.push('none')
   }
 
-  if (!includeSubdomains && scanType === 'website') {
+  if (!includeSubdomains && (scanType === 'website' || scanType === 'intelligent')) {
     options.push('-s')
     options.push('same-hostname')
   }

--- a/src/MainWindow/HomePage/InitScanForm.jsx
+++ b/src/MainWindow/HomePage/InitScanForm.jsx
@@ -388,9 +388,9 @@ const InitScanForm = ({
           isFileOptionChecked
             ? scanTypeOptions.filter(
                 (option) =>
-                  option !== scanTypeOptions[2] && option !== scanTypeOptions[3]
+                  option !== scanTypeOptions[3] && option !== scanTypeOptions[4]
               )
-            : scanTypeOptions.filter((option) => option !== scanTypeOptions[3])
+            : scanTypeOptions.filter((option) => option !== scanTypeOptions[4])
         }
         fileTypesOptions={fileTypesOptions}
         viewportOptions={viewportOptions}

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -4,8 +4,9 @@ import boxRightArrow from '../assets/box-arrow-up-right-purple.svg'
 import deviceDescriptors from './deviceDescriptorsSource.json';
 
 export const scanTypes = {
-  'Website crawl': 'website',
+  'Website crawler (Intelligent)': 'intelligent',
   'Sitemap crawl': 'sitemap',
+  'Website crawler (Legacy)': 'website',
   'Custom flow': 'custom',
   'Local file': 'localfile',
 }


### PR DESCRIPTION
## Summary
- Make the intelligent crawler (`-c 4` / `-c intelligent`) the default scan type, replacing the legacy website crawl (`-c 2` / `-c website`)
- Add "Intelligent" as the first crawler option and relabel the old website crawl as "Legacy"
- Update subdomain restriction logic to also apply for intelligent crawls

## Changes

### Oobee Desktop
- Added "Website crawler (Intelligent)" as the first scan type option mapping to `intelligent`
- Moved previous "Website crawl" to third position as "Website crawler (Legacy)"
- Updated scan type filter indices for the new 5-item list
- Extended subdomain hostname restriction to also apply for `intelligent` scan type

## Test plan
- [ ] Start a scan with the default (Intelligent) option and verify it uses `-c intelligent` end-to-end
- [ ] Switch to Legacy option and verify it still uses `-c website`
- [ ] Switch to Sitemap option and verify it still uses `-c sitemap`
- [ ] Verify "Include Subdomains" checkbox is visible for both Intelligent and Legacy, hidden for Sitemap
- [ ] Verify unchecking subdomains passes `-s same-hostname` for both Intelligent and Legacy crawls
