### PR TITLE
fix: macOS updater prompts for admin password when app is not user-owned

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -162,8 +162,8 @@ app.on('ready', async () => {
     launchWindow.webContents.send('launchStatus', 'checkingUpdates')
   })
 
-  updateEvent.on('promptFrontendUpdate', (userResponse) => {
-    launchWindow.webContents.send('launchStatus', 'promptFrontendUpdate')
+  updateEvent.on('promptFrontendUpdate', (userResponse, versionInfo) => {
+    launchWindow.webContents.send('launchStatus', { status: 'promptFrontendUpdate', ...versionInfo })
     ipcMain.once('proceedUpdate', (_event, response) => {
       userResponse(response)
     })

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -81,6 +81,12 @@ const execCommand = async (command) => {
   return await execution;
 };
 
+const execCommandElevated = async (command) => {
+  const escapedCommand = command.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const osaCommand = `osascript -e 'do shell script "${escapedCommand}" with administrator privileges'`;
+  return execCommand(osaCommand);
+};
+
 // get hash value of prepackage zip
 const hashPrepackage = async (prepackagePath) => {
   const zipFileReadStream = fs.createReadStream(prepackagePath);
@@ -195,26 +201,28 @@ const downloadAndUnzipFrontendMac = async (tag = undefined) => {
     ? `https://github.com/GovTechSG/oobee-desktop/releases/download/${tag}/oobee-desktop-macos.zip`
     : frontendReleaseUrl;
 
-  const command = `
-  mkdir -p '${resultsPath}' &&
-  curl -L '${downloadUrl}' -o '${resultsPath}/oobee-desktop-mac.zip' &&
-  mv '${macOSExecutablePath}' '${path.join(
-    macOSExecutablePath,
-    ".."
-  )}/Oobee Old.app' &&
-  ditto -xk '${resultsPath}/oobee-desktop-mac.zip' '${path.join(
-    macOSExecutablePath,
-    ".."
-  )}' &&
-  rm '${resultsPath}/oobee-desktop-mac.zip' &&
-  rm -rf '${path.join(macOSExecutablePath, "..")}/Oobee Old.app' &&
-  xattr -rd com.apple.quarantine '${path.join(
-    macOSExecutablePath,
-    ".."
-  )}/Oobee.app' `;
+  const parentDir = path.join(macOSExecutablePath, "..");
 
-  await execCommand(command);
+  const downloadCommand = `mkdir -p '${resultsPath}' && curl -L '${downloadUrl}' -o '${resultsPath}/oobee-desktop-mac.zip'`;
 
+  const installCommand = `mv '${macOSExecutablePath}' '${parentDir}/Oobee Old.app' && ditto -xk '${resultsPath}/oobee-desktop-mac.zip' '${parentDir}' && rm '${resultsPath}/oobee-desktop-mac.zip' && rm -rf '${parentDir}/Oobee Old.app' && xattr -rd com.apple.quarantine '${parentDir}/Oobee.app'`;
+
+  await execCommand(downloadCommand);
+
+  let needsElevation = false;
+  try {
+    fs.accessSync(parentDir, fs.constants.W_OK);
+    fs.accessSync(macOSExecutablePath, fs.constants.W_OK);
+  } catch (e) {
+    needsElevation = true;
+  }
+
+  if (needsElevation) {
+    consoleLogger.info("Elevating privileges for app update");
+    await execCommandElevated(installCommand);
+  } else {
+    await execCommand(installCommand);
+  }
 };
 
 /**
@@ -289,7 +297,10 @@ const run = async (updaterEventEmitter, latestRelease, latestPreRelease) => {
   if (toUpdateFrontendVer) {
     consoleLogger.info(`update prompted for version: ${toUpdateFrontendVer}`);
     const userResponse = new Promise((resolve) => {
-      updaterEventEmitter.emit("promptFrontendUpdate", resolve);
+      updaterEventEmitter.emit("promptFrontendUpdate", resolve, {
+        currentVersion: getFrontendVersion(),
+        newVersion: toUpdateFrontendVer,
+      });
     });
 
     proceedUpdate = await userResponse;

--- a/src/LaunchWindow/index.jsx
+++ b/src/LaunchWindow/index.jsx
@@ -44,10 +44,14 @@ const Prompt = ({
 const LaunchWindow = () => {
   const [launchStatus, setLaunchStatus] = useState(null)
   const [promptUpdate, setPromptUpdate] = useState(false)
+  const [versionInfo, setVersionInfo] = useState(null)
 
   useEffect(() => {
     window.services.launchStatus((s) => {
-      if (s === 'promptFrontendUpdate' || s === 'promptBackendUpdate') {
+      if (typeof s === 'object' && s.status === 'promptFrontendUpdate') {
+        setVersionInfo({ currentVersion: s.currentVersion, newVersion: s.newVersion })
+        setPromptUpdate(true)
+      } else if (s === 'promptFrontendUpdate' || s === 'promptBackendUpdate') {
         setPromptUpdate(true)
       } else {
         setLaunchStatus(s)
@@ -113,10 +117,13 @@ const LaunchWindow = () => {
   }
 
   if (promptUpdate) {
+    const versionDesc = versionInfo
+      ? `Current installed: ${versionInfo.currentVersion}, new version ${versionInfo.newVersion} available. Would you like to update now? It may take a few minutes.`
+      : 'Would you like to update now? It may take a few minutes.'
     return (
       <Prompt
         header='New update available'
-        desc='Would you like to update now? It may take a few minutes.'
+        desc={versionDesc}
         proceedLabel='Update'
         proceedHandler={handlePromptUpdateResponse(true)}
         dismissLabel='Later'


### PR DESCRIPTION
Previously the updater silently failed when the .app bundle wasn't writable by the current user (e.g. installed to /Applications by an admin). Now it checks write access first and escalates via osascript to show the native macOS admin auth dialog when needed.

Also displays current and new version numbers in the update prompt.


## Summary

- Fix macOS updater failing silently when the `.app` bundle is not owned by the current user (e.g., installed to `/Applications` by an admin or MDM)
- Automatically escalate to admin privileges via `osascript` (native macOS password dialog) when write access is denied
- Show current and new version numbers in the update prompt (e.g., "Current installed: 0.10.86, new version 0.10.87 available")

## Problem

The macOS frontend updater runs `mv` / `ditto` / `rm` as the current user. If the `.app` bundle isn't writable (common when installed system-wide), the `&&` chain silently aborts and the update never completes. There was no privilege escalation mechanism for macOS, unlike Windows which uses an installer with UAC.

## Solution

1. Split the update into a **download phase** (always user-writable `~/Library/Application Support/Oobee`) and an **install phase** (modifies the `.app` bundle).
2. Before the install phase, check write access with `fs.accessSync`. If denied, re-run the install commands wrapped in `osascript -e 'do shell script "..." with administrator privileges'`, which triggers the standard macOS username/password dialog.
3. Pass version metadata (`currentVersion`, `newVersion`) through the event/IPC chain to display in the update prompt UI.

## Test plan

- [ ] Install Oobee.app to a user-owned location (e.g., `~/Applications/`) — update should work without a password prompt
- [ ] Install Oobee.app to `/Applications` owned by root — update should show the macOS admin auth dialog, then succeed
- [ ] Cancel the password dialog — update should fail gracefully and show the download-failed state
- [ ] Verify the update prompt shows "Current installed: x.x.x, new version y.y.y available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
