### PR TITLE
fix: restore "Adhere to robots.txt" option in Advanced Scan Options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ From `src/common/constants.js`:
 | File Type dropdown | Show | Show | Show | Hide | Show |
 | Allow subdomains for scans | Show | Hide | Show | Hide | Hide |
 | Slow Scan Mode | Show | Show | Show | Hide | Hide |
-| Adhere to robots.txt | Hide (removed) | Hide (removed) | Hide (removed) | Hide (removed) | Hide (removed) |
+| Adhere to robots.txt | Show | Hide | Show | Hide | Hide |
 
 ---
 

--- a/src/MainWindow/HomePage/AdvancedScanOptions.jsx
+++ b/src/MainWindow/HomePage/AdvancedScanOptions.jsx
@@ -256,6 +256,30 @@ const AdvancedScanOptions = ({
               </div>
             )}
 
+          {!isFileOptionChecked &&
+            (advancedOptions.scanType === 'Intelligent crawler' ||
+              advancedOptions.scanType === 'Website crawler') && (
+              <div
+                id="follow-robots-toggle-group"
+                class="advanced-options-toggle-group"
+              >
+                <input
+                  type="checkbox"
+                  id="follow-robots-toggle"
+                  class="advanced-options-toggle"
+                  aria-describedby="follow-robots-tooltip"
+                  checked={advancedOptions.followRobots}
+                  onChange={handleSetAdvancedOption(
+                    'followRobots',
+                    (e) => e.target.checked
+                  )}
+                />
+                <label htmlFor="follow-robots-toggle">
+                  Adhere to robots.txt
+                </label>
+              </div>
+            )}
+
           {/* START: Custom Checks */}
           <div
             id="custom-checks-toggle-group"

--- a/src/MainWindow/HomePage/HomePage.scss
+++ b/src/MainWindow/HomePage/HomePage.scss
@@ -230,6 +230,7 @@
   #false-positive-toggle-group,
   #screenshots-toggle-group,
   #subdomain-toggle-group,
+  #follow-robots-toggle-group,
   #max-concurrency-toggle-group,
   #custom-checks-toggle-group,
   #wcag-aaa-toggle-group {


### PR DESCRIPTION
## What

Restores the **Adhere to robots.txt** checkbox in `AdvancedScanOptions.jsx` that was accidentally removed.

## Why

The option was inadvertently dropped in a previous commit. The checkbox controls the `-r yes` CLI flag passed to the oobee engine, which instructs the crawler to respect `robots.txt` exclusions. Without the UI control, users had no way to enable this behaviour.

## Changes

- `src/MainWindow/HomePage/AdvancedScanOptions.jsx` — re-adds the `follow-robots-toggle-group` checkbox, visible only when:
  - Not in file mode (`!isFileOptionChecked`)
  - Scan type is `Intelligent crawler` or `Website crawler`
- `AGENTS.md` — updates the Control Visibility Matrix to reflect the restored option (`Show` for Intelligent and Website crawler, `Hide` for all others)

## How it works

When the checkbox is checked, `advancedOptions.followRobots` is set to `true`. This propagates through:

1. `services.js` — forwarded in `scanArgs` for both `validateUrlConnectivity` and `startScan`
2. `scanManager.js` `getScanOptions()` — emits `-r yes` to the CLI when `followRobots` is truthy

No changes were needed to the CLI flag handling; the wiring was already intact.