### PR TITLE
fix: re-extract backend when engine version differs from app version

### DIFF
--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -444,27 +444,10 @@ const run = async (updaterEventEmitter, latestRelease, latestPreRelease) => {
           "detected running from dev environment, will not validate/download prepackage"
         );
       } else if (isPrepackageValid) {
-      let skipUnzip = false;
-      if (getBackendExists() && fs.existsSync(hashPath)) {
-        consoleLogger.info("backend and hash path exists");
-        // compare zip file hash to determine whether to unzip
-        const currHash = await hashPrepackage(macOSPrepackageBackend);
-        const hash = fs.readFileSync(hashPath, "utf-8"); // stored hash
-
-        // compare
-        if (hash === currHash) {
-          consoleLogger.info("hash of prepackage and hash path is the same");
-          skipUnzip = true;
-        }
-      }
-
-      if (!skipUnzip) {
-        // expected to reach here when restart triggered on update
-        consoleLogger.info("proceeding to unzip backend prepackage");
-        updaterEventEmitter.emit("settingUp");
-        await unzipBackendAndCleanUp(macOSPrepackageBackend);
-        await hashAndSaveZip(macOSPrepackageBackend);
-      }
+      consoleLogger.info("proceeding to unzip backend prepackage");
+      updaterEventEmitter.emit("settingUp");
+      await unzipBackendAndCleanUp(macOSPrepackageBackend);
+      await hashAndSaveZip(macOSPrepackageBackend);
       } else {
         // unlikely scenario
         consoleLogger.info(

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -5,6 +5,8 @@ const crypto = require("crypto");
 const { exec, spawn } = require("child_process");
 const {
   getFrontendVersion,
+  getEngineVersion,
+  appVersion,
   appPath,
   backendPath,
   resultsPath,
@@ -409,10 +411,31 @@ const run = async (updaterEventEmitter, latestRelease, latestPreRelease) => {
       updaterEventEmitter.emit("restartTriggered");
     }
 
-    // If backend already exists, skip the entire backend setup process
-    // This handles the case where the app was updated and the new bundle doesn't have the prepackage
+    // If backend already exists, check whether the engine version matches the app version.
+    // If versions differ, the bundled prepackage is newer and we need to re-extract.
+    let backendNeedsSetup = !getBackendExists();
+
     if (getBackendExists()) {
-      consoleLogger.info("backend already exists, skipping backend setup");
+      try {
+        const engineVersion = getEngineVersion();
+        if (engineVersion && engineVersion !== appVersion) {
+          consoleLogger.info(
+            `Engine version (${engineVersion}) differs from app version (${appVersion}), re-extracting backend`
+          );
+          backendNeedsSetup = true;
+        } else {
+          consoleLogger.info(
+            `Engine version (${engineVersion}) matches app version (${appVersion}), skipping backend setup`
+          );
+        }
+      } catch (e) {
+        consoleLogger.warn("Unable to read engine version, re-extracting backend");
+        backendNeedsSetup = true;
+      }
+    }
+
+    if (!backendNeedsSetup) {
+      consoleLogger.info("backend already exists and is up to date, skipping backend setup");
     } else {
       const isPrepackageValid = await validateZipFile(macOSPrepackageBackend);
       const isDev = process.env.NODE_ENV === "dev";


### PR DESCRIPTION
## Fix: Re-extract backend when engine version is outdated

### Summary

On macOS, when Oobee Desktop is updated (e.g. from 0.10.93 to 0.10.94), the new app bundle ships a newer `oobee-portable-mac.zip` containing the matching engine version. However, the setup process was **skipping extraction entirely** when `~/Library/Application Support/Oobee/Oobee Backend` already existed — leaving users stuck on the old engine version.

### Root Cause

Two issues in `updateManager.js`:

1. **No version comparison** — if the backend folder existed, setup was skipped unconditionally:
   ```js
   if (getBackendExists()) {
     // skip the entire backend setup
   }
   ```

2. **Hash-based skip could override re-extraction** — even after adding a version check, the inner hash comparison (`backendHash.txt` vs zip hash) could still skip unzipping if the stored hash matched. This happened because the hash file persisted from the previous extraction and could match if the zip file hadn't changed its hash between builds.

### Fix

1. Before skipping setup, read the installed engine version from `Oobee Backend/oobee/package.json` and compare it to the Desktop app version (from root `package.json`). If they differ, proceed with re-extraction.

2. Remove the redundant hash-based skip logic inside the extraction path. The version comparison now fully gates whether extraction is needed — once we decide to extract, we always extract unconditionally.

```
App version:    package.json → "0.10.94"
Engine version: ~/Library/Application Support/Oobee/Oobee Backend/oobee/package.json → "0.10.93"
→ Mismatch detected → delete old backend → extract from bundled zip
```

### Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Fresh install (no backend folder) | Extracts zip | Extracts zip (unchanged) |
| Backend exists, same version | Skips | Skips |
| Backend exists, older version | **Skips (bug)** | **Re-extracts (fixed)** |
| Backend exists, can't read version | Skips | Re-extracts (safe fallback) |

### Windows impact

None. The modified code is inside the `else` branch of `if (os.platform() === "win32")` — it only runs on macOS. Windows backend updates are handled separately via the installer + PowerShell script.

### Test plan

- [ ] Clean install on macOS — verify backend is extracted normally
- [ ] Upgrade from an older Desktop version (e.g. 0.10.93 → 0.10.94) — verify "Setting up" screen appears and backend is re-extracted with the new engine version
- [ ] Launch with matching versions — verify no unnecessary re-extraction (check logs for "skipping backend setup")
- [ ] Simulate corrupted/missing `package.json` in backend — verify re-extraction occurs
- [ ] Verify Windows builds are unaffected
