### PR TITLE
fix: prevent white blank screen from IPC listener leak and GPU context loss

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -29,6 +29,7 @@ const {
   shell,
   session,
   dialog,
+  powerMonitor,
 } = require('electron')
 const Sentry = require('@sentry/electron/main')
 const os = require('os')
@@ -253,6 +254,24 @@ app.on('ready', async () => {
   })
 
   createMainWindow()
+
+  mainWindow.webContents.on('render-process-gone', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.reload()
+    }
+  })
+
+  powerMonitor.on('unlock-screen', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.invalidate()
+    }
+  })
+
+  powerMonitor.on('resume', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.invalidate()
+    }
+  })
 
   const scanEvent = new EventEmitter()
   scanManager.init(scanEvent)

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -82,24 +82,34 @@ contextBridge.exposeInMainWorld("services", {
     });
   },
   scanningUrl: (callback) => {
+    ipcRenderer.removeAllListeners("scanningUrl");
     ipcRenderer.on("scanningUrl", (event, data) => {
       callback(data);
     });
   },
   scanningCompleted: (callback) => {
+    ipcRenderer.removeAllListeners("scanningCompleted");
     ipcRenderer.on("scanningCompleted", () => {
       callback();
     });
   },
   generatingReport: (callback) => {
+    ipcRenderer.removeAllListeners("generatingReport");
     ipcRenderer.on("generatingReport", () => {
       callback();
     });
   },
   killScan: (callback) => {
+    ipcRenderer.removeAllListeners("killScan");
     ipcRenderer.on("killScan", () => {
       callback();
     });
+  },
+  removeAllScanListeners: () => {
+    ipcRenderer.removeAllListeners("scanningUrl");
+    ipcRenderer.removeAllListeners("scanningCompleted");
+    ipcRenderer.removeAllListeners("generatingReport");
+    ipcRenderer.removeAllListeners("killScan");
   },
   userDataExists: (callback) => {
     ipcRenderer.on("userDataExists", (event, data) => {

--- a/src/common/components/ScanningComponent.jsx
+++ b/src/common/components/ScanningComponent.jsx
@@ -6,7 +6,6 @@ import crossCircleIcon from "../../assets/cross-circle.svg";
 import LoadingScanningStatus from "./LoadingScanningStatus";
 
 const ScanningComponent = ({ scanningMessage }) => {
-  const [scannedItems, setScannedItems] = useState([]);
   const [urlItems, setUrlItems] = useState([]);
   const [urlItemComponents, setUrlItemComponents] = useState([]);
   const [pagesScanned, setPagesScanned] = useState(0);
@@ -22,46 +21,53 @@ const ScanningComponent = ({ scanningMessage }) => {
   }, []);
 
   useEffect(() => {
-    if (!scanCompleted) {
-      window.services.scanningUrl((urlItem) => {
-        if (urlItem.status === "scanned") {
-          const currDisplayPageNum = urlItem.urlScannedNum;
-          setDisplayPageNum(currDisplayPageNum);
-          setPagesScanned(currDisplayPageNum);
-        } else {
-          setDisplayPageNum(pagesScanned);
-        }
+    window.services.scanningUrl((urlItem) => {
+      if (urlItem.status === "scanned") {
+        setDisplayPageNum(urlItem.urlScannedNum);
+        setPagesScanned(urlItem.urlScannedNum);
+      } else {
+        setPagesScanned((prev) => {
+          setDisplayPageNum(prev);
+          return prev;
+        });
+      }
 
-        const newUrlItems = [urlItem, ...urlItems].slice(0, 50);
-        setUrlItems(newUrlItems);
-
-        const newUrlItemComponents = [
-          ...newUrlItems.map((urlItem, index) => (
-            <UrlItemComponent key={index} index={index} urlItem={urlItem} />
-          )),
-        ];
-        setUrlItemComponents(newUrlItemComponents);
+      setUrlItems((prev) => {
+        const newUrlItems = [urlItem, ...prev].slice(0, 50);
+        setUrlItemComponents(
+          newUrlItems.map((item, index) => (
+            <UrlItemComponent key={index} index={index} urlItem={item} />
+          ))
+        );
+        return newUrlItems;
       });
+    });
 
-      window.services.scanningCompleted(() => {
-        setDisplayPageNum(pagesScanned);
-        const completedUrlItems = [
-          ...urlItems
-            .map((urlItem, index) => (
-              <UrlItemComponent
-                key={index}
-                index={index}
-                urlItem={urlItem}
-                scanCompleted={true}
-              />
-            ))
-            .slice(0, 50),
-        ];
-        setUrlItemComponents(completedUrlItems);
-        setScanCompleted(true);
+    window.services.scanningCompleted(() => {
+      setPagesScanned((prev) => {
+        setDisplayPageNum(prev);
+        return prev;
       });
-    }
-  });
+      setUrlItems((prev) => {
+        setUrlItemComponents(
+          prev.slice(0, 50).map((item, index) => (
+            <UrlItemComponent
+              key={index}
+              index={index}
+              urlItem={item}
+              scanCompleted={true}
+            />
+          ))
+        );
+        return prev;
+      });
+      setScanCompleted(true);
+    });
+
+    return () => {
+      window.services.removeAllScanListeners();
+    };
+  }, []);
 
   useEffect(() => {
     setDisplayPageWord(displayPageNum === 1 ? "page" : "pages");


### PR DESCRIPTION
The renderer may crash after ~1000 pages scanned due to IPC listeners stacking on every React render (no useEffect deps array, no cleanup). Also adds powerMonitor handlers to recover from GPU context loss after system lock/unlock on Windows, and auto-reloads on renderer crash.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
