### PR TITLE
fix: use SIGTERM instead of SIGKILL to allow scan cleanup on abort

### DIFF
--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -46,7 +46,11 @@ const sanitizeLogPath = (rawPath) => {
 
 const killChildProcess = () => {
   if (currentChildProcess) {
-    currentChildProcess.kill('SIGKILL')
+    const proc = currentChildProcess
+    proc.kill('SIGTERM')
+    setTimeout(() => {
+      try { proc.kill('SIGKILL') } catch {}
+    }, 5000)
   }
 }
 
@@ -480,7 +484,10 @@ const startScan = async (scanDetails, scanEvent) => {
     scan.stdout.setEncoding('utf8')
     scan.stdout.on('data', async (data) => {
       if (killChildProcessSignal) {
-        scan.kill('SIGKILL')
+        scan.kill('SIGTERM')
+        setTimeout(() => {
+          try { scan.kill('SIGKILL') } catch {}
+        }, 5000)
         currentChildProcess = null
         killChildProcessSignal = false
         if (intermediateFolderName) {


### PR DESCRIPTION
## fix: use SIGTERM instead of SIGKILL to allow scan cleanup on abort

### Problem

When a user aborts a scan, the desktop app sends `SIGKILL` to the engine process. `SIGKILL` cannot be caught, so the engine's `SIGTERM`/`SIGINT` cleanup handlers never fire — all browser profile and pool directories are left on disk permanently.

### Changes

- **`public/electron/scanManager.js`** — Replace `scan.kill('SIGKILL')` with `scan.kill('SIGTERM')` in both the `killChildProcess()` function and the inline `killChildProcessSignal` handler. A 5-second `setTimeout` fallback sends `SIGKILL` if the process doesn't exit gracefully.

### Companion PR

- **oobee**: [fix/cleanup-browser-pool-directories](https://github.com/GovTechSG/oobee/pull/new/fix/cleanup-browser-pool-directories) — Adds pool directory cleanup and reduces pool profile size.

### Test plan

- [ ] Abort a scan and verify the engine process exits within 5 seconds
- [ ] Confirm browser profile directories are cleaned up after abort
- [ ] Verify the fallback SIGKILL fires if the engine hangs during cleanup
