### PR TITLE
Fix/combine validate and scan into single process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "purplea11ydesktop",
-  "version": "0.10.97",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "purplea11ydesktop",
-      "version": "0.10.97",
+      "version": "0.11.0",
       "dependencies": {
         "@sentry/electron": "^7.13.0",
         "axios": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purplea11ydesktop",
   "productName": "Oobee",
-  "version": "0.10.97",
+  "version": "0.11.0",
   "private": true,
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "dependencies": {

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -294,6 +294,10 @@ app.on('ready', async () => {
     mainWindow.webContents.send('generatingReport')
   })
 
+  scanEvent.on('scanStarted', () => {
+    mainWindow.webContents.send('scanStarted')
+  })
+
   scanEvent.on('killScan', () => {
     mainWindow.webContents.send('killScan')
   })

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -13,13 +13,6 @@ contextBridge.exposeInMainWorld("services", {
     const chromeExists = await ipcRenderer.invoke("checkChromeExistsOnMac");
     return chromeExists;
   },
-  validateUrlConnectivity: async (scanDetails) => {
-    const results = await ipcRenderer.invoke(
-      "validateUrlConnectivity",
-      scanDetails
-    );
-    return results;
-  },
   startScan: async (scanDetails) => {
     const results = await ipcRenderer.invoke("startScan", scanDetails);
     return results;

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -74,6 +74,12 @@ contextBridge.exposeInMainWorld("services", {
       callback(data);
     });
   },
+  scanStarted: (callback) => {
+    ipcRenderer.removeAllListeners("scanStarted");
+    ipcRenderer.on("scanStarted", () => {
+      callback();
+    });
+  },
   scanningUrl: (callback) => {
     ipcRenderer.removeAllListeners("scanningUrl");
     ipcRenderer.on("scanningUrl", (event, data) => {

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -389,10 +389,10 @@ const startScan = async (scanDetails, scanEvent) => {
     scan.stdout.setEncoding('utf8')
     scan.stdout.on('data', async (data) => {
       if (killChildProcessSignal) {
-        scan.kill('SIGTERM')
+        scan.kill('SIGINT')
         setTimeout(() => {
           try { scan.kill('SIGKILL') } catch {}
-        }, 120000)
+        }, 180000)
         currentChildProcess = null
         killChildProcessSignal = false
         if (intermediateFolderName) {

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -160,110 +160,6 @@ const getScanOptions = (details) => {
   return options
 }
 
-const validateUrlConnectivity = async (scanDetails) => {
-  console.log('Validating URL...')
-
-  const userData = readUserDataFromFile()
-  if (userData) {
-    scanDetails.email = userData.email
-    scanDetails.name = userData.name
-    scanDetails.exportDir = userData.exportDir
-    const success = createExportDir(userData.exportDir)
-    if (!success) return { failedToCreateExportDir: true }
-  }
-
-  const response = await new Promise(async (resolve) => {
-    const check = spawn(
-      'node',
-      [
-        `--max-old-space-size=${getMaxOldSpaceSize()}`,
-        `${enginePath}/dist/cli.js`,
-        ...getScanOptions(scanDetails),
-      ],
-      {
-        cwd: resultsPath,
-        env: {
-          ...process.env,
-          OOBEE_VERBOSE: true,
-          OOBEE_VALIDATE_URL: true,
-          OOBEE_SENTRY_DSN: 'https://9f2001daae75a14b01e65a67eabfa404@o4509047624761344.ingest.us.sentry.io/4510751209160704',
-          PLAYWRIGHT_BROWSERS_PATH: `${playwrightBrowsersPath}`,
-          PATH: getPathVariable(),
-          ...(getProxySettings() && { ALL_PROXY: getProxySettings() }),
-        },
-      }
-    )
-
-    currentChildProcess = check
-
-    
-    check.stderr.setEncoding('utf8')
-    check.stderr.on('data', function (data) {
-      console.log('stderr: ' + data)
-    })
-
-    check.stdout.setEncoding('utf8')
-
-    check.stdout.on('data', async (data) => {
-
-      if (data.includes('"level":"info","message":"PID: ')) {
-        console.log(data);
-      }
-      
-      if (data.includes('Logger writing to:')) {
-        try {
-          const logData = JSON.parse(data);
-          const message = logData.message;
-          const prefix = "Logger writing to: ";
-          const index = message.indexOf(prefix);
-          if (index !== -1) {
-            process.env.OOBEE_ERROR_LOG_PATH = message.substring(index + prefix.length).trim();
-            console.log("Error log path set to:\n", process.env.OOBEE_ERROR_LOG_PATH);
-          }
-        } catch (error) {
-          console.error("Failed to parse log data as JSON:", error);
-        }
-      }
-
-      if (data.includes('An error occured. Log file is located at:')) {
-        const match = data.match(/An error occured\. Log file is located at:\s*(\S+?\.txt)(?=\s|$)/);
-        if (match && match[1]) {
-          process.env.OOBEE_ERROR_LOG_PATH = match[1];
-          console.log("Error log path changed to:\n", process.env.OOBEE_ERROR_LOG_PATH);
-        }
-        
-      }
-
-      if (data.includes('Url is valid')) {
-        resolve({ success: true })
-      }
-  
-    })
-
-    check.on('close', (code) => {
-      let validateErrorLog = "";
-      if (code !== 0) {
-        if (process.env.OOBEE_ERROR_LOG_PATH && fs.existsSync(process.env.OOBEE_ERROR_LOG_PATH)) {
-          validateErrorLog = fs.readFileSync(process.env.OOBEE_ERROR_LOG_PATH).toString();
-        } else {
-          console.log("Url validation log not available.")
-        }
-
-        // Treat no code as termination
-        if (!code) {
-          code = 145;
-        }
-
-        console.log(`Url validation process exited with code ${code}`);
-
-        resolve({ success: false, statusCode: code })
-      }
-      currentChildProcess = null
-    })
-  })
-
-  return response
-}
 
 const startScan = async (scanDetails, scanEvent) => {
   const userData = readUserDataFromFile()
@@ -292,6 +188,7 @@ const startScan = async (scanDetails, scanEvent) => {
     let finalResultsAbsolutePath = null
     let hasStoragePathFromIpc = false
     let noPagesScannedDetected = false
+    let httpResponseCode = null
     let stdoutRemainder = ''
 
     const resolveOnce = (result) => {
@@ -361,6 +258,13 @@ const startScan = async (scanDetails, scanEvent) => {
 
       if (trimmedLine.includes('"level":"info","message":"PID: ')) {
         console.log(trimmedLine)
+      }
+
+      if (trimmedLine.includes('Connectivity Check HTTP Response Code:')) {
+        const codeMatch = trimmedLine.match(/Connectivity Check HTTP Response Code:\s*(\d+)/)
+        if (codeMatch) {
+          httpResponseCode = parseInt(codeMatch[1])
+        }
       }
 
       if (trimmedLine.includes('Logger writing to:')) {
@@ -550,7 +454,7 @@ const startScan = async (scanDetails, scanEvent) => {
       }
 
       currentChildProcess = null
-      resolveOnce({ success: false, statusCode: code ?? 0 })
+      resolveOnce({ success: false, statusCode: code ?? 0, httpResponseCode })
     })
   })
 
@@ -732,10 +636,6 @@ const moveCustomFlowResultsToExportDir = (
 }
 
 const init = (scanEvent) => {
-  ipcMain.handle('validateUrlConnectivity', async (_event, scanDetails) => {
-    return await validateUrlConnectivity(scanDetails)
-  })
-
   ipcMain.handle('startScan', async (_event, scanDetails) => {
     return await startScan(scanDetails, scanEvent)
   })

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -333,6 +333,7 @@ const startScan = async (scanDetails, scanEvent) => {
 
       if (trimmedLine.includes('Starting scan')) {
         console.log(trimmedLine)
+        scanEvent.emit('scanStarted')
       }
 
       parseAndEmitCrawlingLines(trimmedLine)

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -260,17 +260,22 @@ const HomePage = ({ appVersionInfo, setCompletedScanId }) => {
 
     window.localStorage.setItem('scanDetails', JSON.stringify(scanDetails))
 
-    navigate('/scanning', {
-      state: { url: urlWithoutAuth(scanDetails.scanUrl).toString() },
+    let hasNavigatedToScanning = false
+    window.services.scanStarted(() => {
+      hasNavigatedToScanning = true
+      navigate('/scanning', {
+        state: { url: urlWithoutAuth(scanDetails.scanUrl).toString() },
+      })
     })
+
     const scanResponse = await services.startScan(scanDetails)
 
     if (scanResponse.cancelled) {
+      setScanButtonIsClicked(false)
       return
     }
 
     if (scanResponse.failedToCreateExportDir) {
-      navigate('/')
       setScanButtonIsClicked(false)
       setPrevUrlErrorMessage('Unable to create download directory')
       return
@@ -294,7 +299,6 @@ const HomePage = ({ appVersionInfo, setCompletedScanId }) => {
         return
       }
 
-      navigate('/')
       setScanButtonIsClicked(false)
       const match = Object.values(urlCheckStatuses).find(
         (s) => s.code === scanResponse.statusCode
@@ -308,16 +312,14 @@ const HomePage = ({ appVersionInfo, setCompletedScanId }) => {
       return
     }
 
-    if (scanResponse.statusCode) {
-      console.error(
-        `unexpected status error: (code ${scanResponse.statusCode})`,
-        scanResponse.message
-      )
+    if (hasNavigatedToScanning) {
+      navigate('/error', {
+        state: { errorState: errorStates.noPagesScannedError, timeOfScan },
+      })
+    } else {
+      setScanButtonIsClicked(false)
+      setPrevUrlErrorMessage('Something went wrong. Please try again later.')
     }
-
-    navigate('/error', {
-      state: { errorState: errorStates.noPagesScannedError, timeOfScan },
-    })
   }
 
   const areUserDetailsSet = name !== '' && email !== ''

--- a/src/MainWindow/HomePage/index.jsx
+++ b/src/MainWindow/HomePage/index.jsx
@@ -260,69 +260,64 @@ const HomePage = ({ appVersionInfo, setCompletedScanId }) => {
 
     window.localStorage.setItem('scanDetails', JSON.stringify(scanDetails))
 
-    const checkUrlResponse = await services.validateUrlConnectivity(scanDetails)
-    if (checkUrlResponse.success) {
-      navigate('/scanning', {
-        state: { url: urlWithoutAuth(scanDetails.scanUrl).toString() },
-      })
-      const scanResponse = await services.startScan(scanDetails)
+    navigate('/scanning', {
+      state: { url: urlWithoutAuth(scanDetails.scanUrl).toString() },
+    })
+    const scanResponse = await services.startScan(scanDetails)
 
-      if (scanResponse.cancelled) {
-        return
-      }
+    if (scanResponse.cancelled) {
+      return
+    }
 
-      if (scanResponse.failedToCreateExportDir) {
-        setPrevUrlErrorMessage('Unable to create download directory')
-        return
-      }
+    if (scanResponse.failedToCreateExportDir) {
+      navigate('/')
+      setScanButtonIsClicked(false)
+      setPrevUrlErrorMessage('Unable to create download directory')
+      return
+    }
 
-      if (scanResponse.success) {
-        setCompletedScanId(scanResponse.scanId)
-        if (scanDetails.scanType === 'Custom flow') {
-          navigate('/custom_flow', { state: { scanDetails } })
-        } else {
-          navigate('/result')
-        }
-        return
+    if (scanResponse.success) {
+      setCompletedScanId(scanResponse.scanId)
+      if (scanDetails.scanType === 'Custom flow') {
+        navigate('/custom_flow', { state: { scanDetails } })
       } else {
-        /* When no pages were scanned (e.g. out of domain upon redirects when valid URL was entered),
-                redirects user to error page to going to result page with empty result */
+        navigate('/result')
+      }
+      return
+    }
+
+    if (cliErrorCodes.has(scanResponse.statusCode)) {
+      if (scanResponse.statusCode === cliErrorTypes.browserError) {
         navigate('/error', {
-          state: { errorState: errorStates.noPagesScannedError, timeOfScan },
+          state: { errorState: errorStates.browserError, timeOfScan },
         })
         return
       }
-    } else {
+
+      navigate('/')
       setScanButtonIsClicked(false)
-      if (checkUrlResponse.failedToCreateExportDir) {
-        setPrevUrlErrorMessage('Unable to create download directory')
-        return
+      const match = Object.values(urlCheckStatuses).find(
+        (s) => s.code === scanResponse.statusCode
+      )
+      let msg = match && 'message' in match ? match.message : 'Something went wrong. Please try again later.'
+      if (scanResponse.httpResponseCode) {
+        msg += ` (HTTP ${scanResponse.httpResponseCode})`
       }
-
-      if (cliErrorCodes.has(checkUrlResponse.statusCode)) {
-        if (checkUrlResponse.statusCode === cliErrorTypes.browserError) {
-          navigate('/error', {
-            state: { errorState: errorStates.browserError, timeOfScan },
-          })
-          return
-        }
-
-        // Use messages from urlCheckStatuses when available
-        const statuses = urlCheckStatuses
-        const match = Object.values(statuses).find(
-          (s) => s.code === checkUrlResponse.statusCode
-        )
-        const msg = match && 'message' in match ? match.message : 'Something went wrong.  Please try again later.'
-        console.log(msg)
-        setPrevUrlErrorMessage(msg)
-        return
-      } else if (checkUrlResponse.statusCode) {
-        console.error(
-          `unexpected status error: (code ${checkUrlResponse.statusCode})`,
-          checkUrlResponse.message
-        )
-      }
+      console.log(msg)
+      setPrevUrlErrorMessage(msg)
+      return
     }
+
+    if (scanResponse.statusCode) {
+      console.error(
+        `unexpected status error: (code ${scanResponse.statusCode})`,
+        scanResponse.message
+      )
+    }
+
+    navigate('/error', {
+      state: { errorState: errorStates.noPagesScannedError, timeOfScan },
+    })
   }
 
   const areUserDetailsSet = name !== '' && email !== ''

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -59,7 +59,7 @@ export const getDefaultAdvancedOptions = () => {
 }
 
 // exit codes returned by Oobee cli when there is an error with the URL provided
-export const cliErrorCodes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+export const cliErrorCodes = new Set([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23])
 export const cliErrorTypes = {
   invalidUrl: 11,
   cannotBeResolved: 12,
@@ -81,9 +81,8 @@ export const urlCheckStatuses = {
   invalidUrl: { code: 11, message: 'Invalid URL. Please check and try again.' },
   cannotBeResolved: { code: 12, message: 'URL cannot be accessed. Please verify whether the website exists.' },
   errorStatusReceived: {
-    // unused for now
     code: 13,
-    message: 'Provided URL cannot be accessed. Server responded with code ', // append it with the response code received,
+    message: 'Provided URL cannot be accessed. Server responded with an error status code.',
   },
   systemError: { code: 14, message: 'Something went wrong when verifying the URL. Please try again in a few minutes. If this issue persists, please contact the Oobee team.'},
   notASitemap: { code: 15, message: 'Invalid sitemap URL format. Please enter a valid sitemap URL ending with .XML or .TXT e.g. https://www.example.com/sitemap.xml.' },

--- a/src/services.js
+++ b/src/services.js
@@ -15,55 +15,6 @@ import {
 let currentScanUrl
 let currentScanType
 
-const validateUrlConnectivity = async (scanDetails) => {
-  const {
-    scanType: selectedScanType,
-    scanUrl,
-    viewport,
-    device,
-    viewportWidth,
-    browser,
-    fileTypes: selectedFileTypes,
-    customChecks,
-    wcagAaa,
-    maxConcurrency,
-    includeScreenshots,
-    includeSubdomains,
-    followRobots,
-  } = scanDetails
-
-  currentScanUrl = scanUrl
-  currentScanType = selectedScanType
-
-  const scanArgs = {
-    scanType: scanTypes[selectedScanType],
-    url: scanUrl,
-    browser: browser,
-    fileTypes: fileTypes[selectedFileTypes],
-    customChecks: customChecks,
-    wcagAaa: wcagAaa,
-    maxConcurrency: maxConcurrency,
-    includeScreenshots,
-    includeSubdomains,
-    followRobots,
-  }
-
-  if (viewport === viewportTypes.mobile) {
-    scanArgs.customDevice = 'Mobile'
-  }
-
-  if (viewport === viewportTypes.specific) {
-    scanArgs.customDevice = devices[device]
-  }
-
-  if (viewport === viewportTypes.custom) {
-    scanArgs.viewportWidth = viewportWidth
-  }
-
-  const response = await window.services.validateUrlConnectivity(scanArgs)
-  return response
-}
-
 const startScan = async (scanDetails) => {
   const {
     scanType: selectedScanType,
@@ -249,7 +200,6 @@ const services = {
   getIsWindows,
   isValidName,
   isValidCustomFlowLabel,
-  validateUrlConnectivity,
   getErrorLog,
 }
 


### PR DESCRIPTION
## Summary

Combines the two-step scan flow (validate URL connectivity + actual scan) into a single process. Previously, Oobee Desktop spawned the Oobee CLI twice — once with `OOBEE_VALIDATE_URL=true` just to check connectivity, and again without it to run the actual scan. Since the Oobee engine already performs the same connectivity check at the start of every scan and exits with distinct error codes (11-23) on failure, the separate validation step was redundant.

**Net result: -150 lines, faster scan start (eliminates ~3s duplicate connectivity check), no changes to Oobee engine required.**

## Changes

- **Remove `validateUrlConnectivity`** from scanManager, preload, and services — no longer spawns a separate process just to validate
- **Add `scanStarted` event** — emitted when Oobee outputs "Starting scan" (after connectivity check passes), so the UI knows when to transition from spinner to scanning progress
- **Restructure HomePage scan flow** — button shows spinner during connectivity check; navigates to `/scanning` only after `scanStarted` fires; connectivity errors display inline below the URL input
- **Parse HTTP response code from stdout** — surfaces the actual HTTP status (e.g., `HTTP 500`) in error messages for better user context
- **Add missing error codes 21/22/23 to `cliErrorCodes`** — `notASupportedDocument`, `connectionRefused`, `timedOut` were defined in `urlCheckStatuses` but not matched
- **Fix incomplete message for exit code 13** — was `"Server responded with code "` (trailing space), now a complete sentence

## UX Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Invalid URL | Spinner → error inline | Spinner → error inline (same) |
| DNS failure | Spinner → error inline | Spinner → error inline (same) |
| Auth required (401) | Spinner → Basic Auth modal | Spinner → Basic Auth modal (same) |
| Browser not found | Spinner → error page | Spinner → error page (same) |
| Successful scan | Spinner (3s) → scanning page → result | Spinner (3s) → scanning page → result (same, but 3s faster overall) |
| No pages scanned | Spinner → scanning page → error page | Spinner → scanning page → error page (same) |

## Test Plan

- [ ] Scan a valid URL (e.g., `https://www.google.com`) — should show spinner, then scanning progress, then results
- [ ] Scan a fictitious URL (e.g., `https://www.acme.gov.sg`) — should show spinner, then inline error message below URL input
- [ ] Scan with no internet connection — should show "No internet connection" immediately (client-side check, unchanged)
- [ ] Abort scan during scanning phase — should cancel cleanly
- [ ] Verify Basic Auth modal still appears for 401-protected URLs
- [ ] Verify no `validateUrlConnectivity` references remain in source (only in stale `build/`)
