### PR TITLE
fix(update-prompt): reliably detect Admin By Request elevation on macOS

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -54,6 +54,19 @@ marked.use({
 })
 const fs = require('fs')
 const path = require('path')
+const { execFileSync, spawnSync } = require('child_process')
+
+// Runs a command and captures status/stdout/stderr without throwing on
+// non-zero exit — needed because `dseditgroup -o checkmember` legitimately
+// exits non-zero to signal "not a member".
+function captureCmd(bin, args) {
+  const r = spawnSync(bin, args, { encoding: 'utf8' })
+  return {
+    status: r.status,
+    stdout: (r.stdout || '').trim(),
+    stderr: (r.stderr || '').trim(),
+  }
+}
 
 const app = electronApp
 
@@ -73,10 +86,37 @@ Sentry.init({
 let launchWindow
 let mainWindow
 
+// We can't rely on an fs write probe from this process, because Electron's
+// kauth credentials are snapshotted at launch — Admin By Request's JIT admin
+// grant doesn't propagate into an already-running process, so the probe keeps
+// failing even after the user has been elevated. Query DirectoryService via
+// three complementary tools and treat the user as elevated if any of them
+// reports admin-group membership — different ABR configurations reflect the
+// grant through different lookup paths.
+function isCurrentUserInAdminGroup() {
+  const username = os.userInfo().username
+  const dseditgroup = captureCmd('/usr/sbin/dseditgroup', ['-o', 'checkmember', '-m', username, 'admin'])
+  const idGn = captureCmd('/usr/bin/id', ['-Gn', username])
+  const dscl = captureCmd('/usr/bin/dscl', ['.', '-read', '/Groups/admin', 'GroupMembership'])
+
+  // dseditgroup always prints "yes X is a member" / "no X is NOT a member" on
+  // stdout regardless of exit code, so parse stdout for portability.
+  const dseditgroupSaysMember = /^yes\b/i.test(dseditgroup.stdout)
+  const idGnSaysMember = idGn.stdout.split(/\s+/).includes('admin')
+  const dsclSaysMember = new RegExp(`\\b${username}\\b`).test(dscl.stdout)
+
+  return dseditgroupSaysMember || idGnSaysMember || dsclSaysMember
+}
+
+function computeNeedsElevation() {
+  if (process.platform !== 'darwin') return false
+  return !isCurrentUserInAdminGroup()
+}
+
 function createLaunchWindow() {
   launchWindow = new BrowserWindow({
-    width: 430,
-    height: 400,
+    width: 480,
+    height: 480,
     frame: false,
     webPreferences: {
       preload: constants.preloadPath,
@@ -163,6 +203,14 @@ app.on('ready', async () => {
   await launchWindowReady
   launchWindow.webContents.send('appStatus', 'launch')
 
+  // Register the elevation-check IPC handler BEFORE updateManager.run so that
+  // the renderer's polling loop (which starts as soon as the "Update available"
+  // screen renders) can reach it. updateManager.run awaits the user's Update /
+  // Later response, so any handler registered after it does not exist for the
+  // duration of the prompt — every invoke() rejects, and the setInterval
+  // callback swallows the rejection silently.
+  ipcMain.handle('checkNeedsElevation', () => computeNeedsElevation())
+
   // this is used for listening to messages that updateManager sends
   const updateEvent = new EventEmitter()
 
@@ -175,7 +223,11 @@ app.on('ready', async () => {
   })
 
   updateEvent.on('promptFrontendUpdate', (userResponse, versionInfo) => {
-    launchWindow.webContents.send('launchStatus', { status: 'promptFrontendUpdate', ...versionInfo })
+    launchWindow.webContents.send('launchStatus', {
+      status: 'promptFrontendUpdate',
+      ...versionInfo,
+      adminByRequestPresent: computeNeedsElevation(),
+    })
     ipcMain.once('proceedUpdate', (_event, response) => {
       userResponse(response)
     })

--- a/public/electron/preload.js
+++ b/public/electron/preload.js
@@ -149,6 +149,7 @@ contextBridge.exposeInMainWorld("services", {
       return filePath;
     },
     getIsWindows: async () => ipcRenderer.invoke("isWindows"),
+    checkNeedsElevation: async () => ipcRenderer.invoke("checkNeedsElevation"),
     getProxySettings: async () => ipcRenderer.invoke("getProxySettings"),
     setProxySettings: async (proxyValue) => ipcRenderer.invoke("setProxySettings", proxyValue),
     getIncludeProxy: async () => ipcRenderer.invoke("getIncludeProxy"),

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -109,13 +109,15 @@ const execCommandStrict = async (command) => {
 // wrapped with sh -c "osascript -e '...single-quoted paths...'", which bash
 // silently mis-parsed, so osascript received a scrambled script and no admin
 // prompt ever appeared.
-const execCommandElevated = async (command) => {
+const execCommandElevated = async (command, prompt = "Updater wants to install new version of accessibility scanner") => {
   // Escape for AppleScript's "..." string literal. Single quotes need no
   // escaping since the surrounding delimiters are double quotes.
-  const appleScriptEscaped = command
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"');
-  const appleScript = `do shell script "${appleScriptEscaped}" with administrator privileges`;
+  const escapeForAppleScript = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const appleScriptEscaped = escapeForAppleScript(command);
+  // `with prompt "..."` replaces the default "osascript wants to make changes"
+  // line in the macOS authentication dialog with our own message.
+  const promptEscaped = escapeForAppleScript(prompt);
+  const appleScript = `do shell script "${appleScriptEscaped}" with prompt "${promptEscaped}" with administrator privileges`;
 
   return new Promise((resolve, reject) => {
     const proc = spawn("osascript", ["-e", appleScript], { cwd: appPath });
@@ -265,9 +267,17 @@ const downloadAndUnzipFrontendMac = async (tag = undefined) => {
 
   const downloadCommand = `mkdir -p '${resultsPath}' && curl -L '${downloadUrl}' -o '${resultsPath}/oobee-desktop-mac.zip'`;
 
-  // Use a temporary name that won't trigger macOS security warnings
+  // Use a temporary name that won't trigger macOS security warnings.
+  //
+  // The command must be idempotent for retry: if the unprivileged attempt
+  // partially mutates state (e.g. the `mv` completes but a later step fails
+  // because ABR elevation ends mid-flow), the elevated retry runs the same
+  // string and would otherwise fail at `mv` because its source is gone. So:
+  //   - `mv` is guarded by an existence check on the source
+  //   - `rm` on the zip uses -f so a missing file isn't fatal
+  //   - `rm -rf` on the temp app is already tolerant of a missing target
   const tempAppName = `.Oobee.tmp.${Date.now()}.app`;
-  const installCommand = `mv '${macOSExecutablePath}' '${parentDir}/${tempAppName}' && ditto -xk '${resultsPath}/oobee-desktop-mac.zip' '${parentDir}' && rm '${resultsPath}/oobee-desktop-mac.zip' && rm -rf '${parentDir}/${tempAppName}' && xattr -rd com.apple.quarantine '${parentDir}/Oobee.app'`;
+  const installCommand = `{ [ ! -e '${macOSExecutablePath}' ] || mv '${macOSExecutablePath}' '${parentDir}/${tempAppName}'; } && ditto -xk '${resultsPath}/oobee-desktop-mac.zip' '${parentDir}' && rm -f '${resultsPath}/oobee-desktop-mac.zip' && rm -rf '${parentDir}/${tempAppName}' && xattr -rd com.apple.quarantine '${parentDir}/Oobee.app'`;
 
   await execCommand(downloadCommand);
 

--- a/src/LaunchWindow/index.jsx
+++ b/src/LaunchWindow/index.jsx
@@ -7,10 +7,12 @@ import newUpdateImg from '../../src/assets/box-seam.svg'
 const Prompt = ({
   header,
   desc,
+  extraNote,
   proceedLabel,
   dismissLabel,
   proceedHandler,
   dismissHandler,
+  hideProceed,
 }) => {
   return (
     <div id='launch-window'>
@@ -24,17 +26,27 @@ const Prompt = ({
       <div>
         <h1>{header}</h1>
         <p>{desc}</p>
+        {extraNote && (
+          <p className='extra-note' style={{ fontWeight: 700 }}>
+            {extraNote}
+          </p>
+        )}
         <div className='d-flex justify-content-center'>
-          <Button type='btn-secondary' onClick={dismissHandler}>
+          <Button
+            type={hideProceed ? 'btn-primary' : 'btn-secondary'}
+            onClick={dismissHandler}
+          >
             {dismissLabel}
           </Button>
-          <Button
-            id='proceed-button'
-            type='btn-primary'
-            onClick={proceedHandler}
-          >
-            {proceedLabel}
-          </Button>
+          {!hideProceed && (
+            <Button
+              id='proceed-button'
+              type='btn-primary'
+              onClick={proceedHandler}
+            >
+              {proceedLabel}
+            </Button>
+          )}
         </div>
       </div>
     </div>
@@ -49,7 +61,11 @@ const LaunchWindow = () => {
   useEffect(() => {
     window.services.launchStatus((s) => {
       if (typeof s === 'object' && s.status === 'promptFrontendUpdate') {
-        setVersionInfo({ currentVersion: s.currentVersion, newVersion: s.newVersion })
+        setVersionInfo({
+          currentVersion: s.currentVersion,
+          newVersion: s.newVersion,
+          adminByRequestPresent: s.adminByRequestPresent,
+        })
         setPromptUpdate(true)
       } else if (s === 'promptFrontendUpdate' || s === 'promptBackendUpdate') {
         setPromptUpdate(true)
@@ -76,6 +92,24 @@ const LaunchWindow = () => {
       setPromptUpdate(false)
     }
   }, [launchStatus])
+
+  useEffect(() => {
+    if (!promptUpdate) return
+    if (!window.services?.checkNeedsElevation) return
+    const intervalId = setInterval(async () => {
+      try {
+        const needsElevation = await window.services.checkNeedsElevation()
+        setVersionInfo((prev) => {
+          if (!prev) return prev
+          if (prev.adminByRequestPresent === needsElevation) return prev
+          return { ...prev, adminByRequestPresent: needsElevation }
+        })
+      } catch (err) {
+        console.error('[ABR-poll] checkNeedsElevation failed:', err)
+      }
+    }, 5000)
+    return () => clearInterval(intervalId)
+  }, [promptUpdate])
 
   const messages = {
     settingUp: {
@@ -120,14 +154,19 @@ const LaunchWindow = () => {
     const versionDesc = versionInfo
       ? `Current installed: ${versionInfo.currentVersion}, new version ${versionInfo.newVersion} available. Would you like to update now? It may take a few minutes.`
       : 'Would you like to update now? It may take a few minutes.'
+    const extraNote = versionInfo && versionInfo.adminByRequestPresent
+      ? 'Note: Admin user rights for this device is required for this update to be successful.'
+      : null
     return (
       <Prompt
         header='New update available'
         desc={versionDesc}
+        extraNote={extraNote}
         proceedLabel='Update'
         proceedHandler={handlePromptUpdateResponse(true)}
         dismissLabel='Later'
         dismissHandler={handlePromptUpdateResponse(false)}
+        hideProceed={!!extraNote}
       />
     )
   }


### PR DESCRIPTION
# Improved Admin By Request handling on macOS updater

## Summary

Adds dynamic Admin By Request (ABR) awareness to the "Update available" screen on macOS, so the update flow reflects the user's current elevation state and the auth dialog identifies itself clearly.

## Improvements

### 1. Dynamic elevation state on the Update available screen

The "Update available" prompt now reacts to ABR session changes in real time. While the screen is open, the app polls the user's elevation state every ~5s and updates the UI both ways:

- ABR session enabled while the screen is open → the "admin rights required" note is dismissed and the **Update** button appears within a few seconds.
- ABR session ended → the note returns and the **Update** button is hidden again.

Previously the screen only reflected elevation state at the moment it opened.

### 2. More resilient elevation detection

Elevation detection no longer relies on the Electron process's filesystem write-probe — that probe uses the process's launch-time `kauth` credentials and can't observe ABR's JIT admin grant. It now consults DirectoryService via three complementary tools in parallel and treats the user as elevated if any of them reports admin membership:

- `dseditgroup -o checkmember -m $user admin` (OpenDirectory query)
- `id -Gn $user` (`getgrouplist(3)`)
- `dscl . -read /Groups/admin GroupMembership` (local DS node)

Different ABR configurations surface the grant through different lookup paths, so an OR of the three is resilient across managed environments.

### 3. Clearer macOS authentication dialog

The elevation dialog now identifies the requester with a purpose-specific message via `with prompt "…"` on the AppleScript passed to `osascript`. Instead of the generic "osascript wants to make changes", users see:

> **Updater wants to install new version of accessibility scanner**

### 4. Retry-safe install command

The update install runs try-unprivileged → fall-back-to-elevated. The install command is now idempotent so the elevated retry can safely re-run the same string:

- `mv` of the current app bundle is guarded by an existence check on its source
- `rm` on the downloaded zip uses `-f` so a re-run doesn't die on a missing file

## Files changed

- [public/electron/main.js](public/electron/main.js) — multi-detector elevation check, hoisted IPC handler registration
- [public/electron/preload.js](public/electron/preload.js) — expose `checkNeedsElevation` to the renderer
- [public/electron/updateManager.js](public/electron/updateManager.js) — idempotent install command, custom auth-dialog prompt
- [src/LaunchWindow/index.jsx](src/LaunchWindow/index.jsx) — bidirectional polling of elevation state while the Update available screen is open

## Known limitation

If your ABR deployment operates in AuthorizationPlugin mode (intercepts the `system.privilege.admin` prompt rather than temporarily adding the user to the `admin` group), none of the group-membership detectors will observe the state change during an active session. Detecting that mode reliably requires a native helper that calls `AuthorizationCopyRights` on `system.privilege.admin` non-interactively, which is out of scope for this PR.

## Test plan

- [ ] Launch on macOS **without** ABR active on a version with an available update → Update available screen shows only the **Later** button; the "admin user rights required" note is visible.
- [ ] Enable ABR session while the screen is open → within ~5s, the note disappears and the **Update** button appears.
- [ ] End ABR session → within ~5s, the note reappears and the **Update** button hides.
- [ ] Click **Update** with ABR active → macOS auth dialog title reads *"Updater wants to install new version of accessibility scanner"*; ABR intercepts the prompt.
- [ ] After successful auth, install completes and the app relaunches on the new version.
- [ ] Launch on macOS **as a local admin user** → Update button shows immediately, unprivileged install path succeeds without an auth prompt.
- [ ] Launch on Windows → unchanged behavior (all mac-only code paths are gated on `process.platform === 'darwin'`).
