### PR TITLE
fix(update-prompt): skip ABR admin check when app bundle is user-writable

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -86,13 +86,13 @@ Sentry.init({
 let launchWindow
 let mainWindow
 
-// We can't rely on an fs write probe from this process, because Electron's
-// kauth credentials are snapshotted at launch — Admin By Request's JIT admin
-// grant doesn't propagate into an already-running process, so the probe keeps
-// failing even after the user has been elevated. Query DirectoryService via
-// three complementary tools and treat the user as elevated if any of them
-// reports admin-group membership — different ABR configurations reflect the
-// grant through different lookup paths.
+// We can't rely on an fs write probe from this process for the admin-group
+// question, because Electron's kauth credentials are snapshotted at launch —
+// Admin By Request's JIT admin grant doesn't propagate into an already-running
+// process, so the probe keeps failing even after the user has been elevated.
+// Query DirectoryService via three complementary tools and treat the user as
+// elevated if any of them reports admin-group membership — different ABR
+// configurations reflect the grant through different lookup paths.
 function isCurrentUserInAdminGroup() {
   const username = os.userInfo().username
   const dseditgroup = captureCmd('/usr/sbin/dseditgroup', ['-o', 'checkmember', '-m', username, 'admin'])
@@ -108,8 +108,31 @@ function isCurrentUserInAdminGroup() {
   return dseditgroupSaysMember || idGnSaysMember || dsclSaysMember
 }
 
+// POSIX write permission on the .app bundle and its parent directory is
+// resolved from filesystem ownership/ACLs, not from the process's cached
+// group credentials, so an fs write probe IS reliable for this question
+// (unlike the admin-group question above). If both are writable, the
+// unprivileged install path in updateManager will succeed without any
+// admin prompt — regardless of whether the user is in the admin group.
+function isAppBundleWritable() {
+  try {
+    const bundlePath = constants.macOSExecutablePath
+    if (!bundlePath) return false
+    const parentDir = path.join(bundlePath, '..')
+    fs.accessSync(parentDir, fs.constants.W_OK)
+    fs.accessSync(bundlePath, fs.constants.W_OK)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 function computeNeedsElevation() {
   if (process.platform !== 'darwin') return false
+  // If the install location is user-writable (e.g. ~/Applications or any
+  // non-/Applications path the user owns), no admin rights are needed to
+  // replace the bundle — skip the ABR check entirely.
+  if (isAppBundleWritable()) return false
   return !isCurrentUserInAdminGroup()
 }
 


### PR DESCRIPTION
# fix(update-prompt): skip ABR admin check when app bundle is user-writable

## Summary

The macOS update prompt was over-eagerly gating the Update button behind an
Admin By Request (ABR) elevation check. Any user outside the local `admin`
group saw the "Admin user rights for this device is required for this update
to be successful" note and had the Update button hidden — even when the `.app`
bundle lived in a directory the user already owns (e.g. `~/Applications`, a
portable install path, or any non-`/Applications` location).

In those cases the unprivileged install path in `updateManager` succeeds on
its own — no admin credentials, no ABR interaction — so the warning was
spurious and blocked users from updating.

## Change

`computeNeedsElevation()` in [public/electron/main.js](public/electron/main.js)
now short-circuits to `false` when an `fs.accessSync(W_OK)` probe on both
the `.app` bundle and its parent directory succeeds. Only if the write
probe fails does it fall through to the existing DirectoryService-based
admin-group lookup that drives the ABR warning.

```
computeNeedsElevation()
  ├── non-darwin?                     → false
  ├── bundle + parent dir writable?   → false   ← new
  └── user in admin group?            → !member
```

## Why the fs write probe is reliable here (but wasn't before)

The existing code carried a comment explaining that a write probe is
**unreliable** from an already-running Electron process, because kauth
credentials are snapshotted at launch and ABR's JIT admin grant doesn't
propagate. That caveat applies to using a probe as a proxy for **"is the
user currently an admin?"** — the group membership can change after launch
in ways the process can't see.

Write permission on a specific filesystem path is a different question: it
resolves from the file's ownership/mode/ACLs at the time of the syscall, not
from the process's cached group credentials. So the probe correctly answers
**"can the unprivileged install path replace this bundle?"** — which is the
only question the elevation warning actually cares about.

## Behavior matrix

| Install location                        | User in admin group | Before          | After           |
|-----------------------------------------|---------------------|-----------------|-----------------|
| `~/Applications` (user-owned)           | No                  | Warning + hidden button (wrong) | Update button visible |
| `~/Applications` (user-owned)           | Yes                 | Update button visible | Update button visible |
| `/Applications` (root:admin, 0775)      | No                  | Warning + hidden button | Warning + hidden button |
| `/Applications` (root:admin, 0775)      | Yes                 | Update button visible | Update button visible |
| Non-macOS                               | —                   | Update button visible | Update button visible |

Only the top row changes.

## Test plan

- [ ] macOS build installed in `~/Applications` as a non-admin user: launch, trigger an update prompt, confirm the "Admin user rights…" note is absent and the Update button is visible.
- [ ] macOS build installed in `/Applications` as a non-admin user: launch, trigger an update prompt, confirm the note and hidden button still appear (existing ABR flow unchanged).
- [ ] macOS build installed in `/Applications` as an admin user: launch, trigger an update prompt, confirm the Update button is visible (existing flow unchanged).
- [ ] End-to-end update completes successfully via the unprivileged path from `~/Applications`.
- [ ] End-to-end update completes successfully via the elevated path from `/Applications` (ABR prompt appears as before).
- [ ] Windows build launches normally (non-darwin branch returns `false` before reaching the new probe).
