### PR TITLE
fix: update cleanup for Crawlee 3.18 storage layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "purplea11ydesktop",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "purplea11ydesktop",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "dependencies": {
         "@sentry/electron": "^7.13.0",
         "axios": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purplea11ydesktop",
   "productName": "Oobee",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "dependencies": {

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -780,9 +780,10 @@ const cleanUpIntermediateFolders = async (
 }
 
 /**
- * Remove crawlee intermediate subfolders (crawlee, crawlee_rq, tmp-items)
- * from the export directory results folder after a cancelled scan.
- * The results folder itself is preserved (user may want partial artifacts).
+ * Remove crawlee intermediate subfolders (datasets, request_queues,
+ * key_value_stores, tmp-items) from the export directory results folder
+ * after a cancelled scan. The results folder itself is preserved (user
+ * may want partial artifacts).
  */
 const cleanUpExportDirCrawleeFiles = async (folderName) => {
   const userData = readUserDataFromFile()
@@ -791,7 +792,7 @@ const cleanUpExportDirCrawleeFiles = async (folderName) => {
   const exportResultsDir = path.join(userData.exportDir, folderName)
   if (!await fs.pathExists(exportResultsDir)) return
 
-  for (const dirName of ['crawlee', 'crawlee_rq', 'tmp-items']) {
+  for (const dirName of ['datasets', 'request_queues', 'key_value_stores', 'tmp-items']) {
     const dirPath = path.join(exportResultsDir, dirName)
     if (fs.existsSync(dirPath)) {
       await retryRemove(dirPath, `export ${dirName}`)


### PR DESCRIPTION
## Summary

`cleanUpExportDirCrawleeFiles` sweeps intermediate Crawlee artifacts from the export directory after a cancelled scan. Crawlee 3.18 (shipping in oobee 0.11.8) changed the on-disk layout, so the sweep list needs updating — otherwise cancelled scans leave the new `datasets/`, `request_queues/`, and `key_value_stores/` folders behind in the user's export folder.

## Layout change

```
Before                       After
<results>/crawlee/           <results>/datasets/
<results>/crawlee_rq/        <results>/request_queues/
                             <results>/key_value_stores/
<results>/tmp-items/         <results>/tmp-items/  (unchanged — oobee's own folder)
```

## Test plan

- [ ] Cancel an in-progress scan → export folder does not retain `datasets/`, `request_queues/`, `key_value_stores/`, or `tmp-items/`
- [ ] Export folder itself is removed if empty after cleanup

## Requires

oobee 0.11.8+ — GovTechSG/oobee `fix/crawlee-3.18-upgrade`
