### PR TITLE
Revert "fix: update cleanup for Crawlee 3.18 storage layout (#273)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "purplea11ydesktop",
-  "version": "0.11.8",
+  "version": "0.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "purplea11ydesktop",
-      "version": "0.11.8",
+      "version": "0.11.7",
       "dependencies": {
         "@sentry/electron": "^7.13.0",
         "axios": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purplea11ydesktop",
   "productName": "Oobee",
-  "version": "0.11.8",
+  "version": "0.11.7",
   "private": true,
   "author": "Government Technology Agency <info@tech.gov.sg>",
   "dependencies": {

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -780,10 +780,9 @@ const cleanUpIntermediateFolders = async (
 }
 
 /**
- * Remove crawlee intermediate subfolders (datasets, request_queues,
- * key_value_stores, tmp-items) from the export directory results folder
- * after a cancelled scan. The results folder itself is preserved (user
- * may want partial artifacts).
+ * Remove crawlee intermediate subfolders (crawlee, crawlee_rq, tmp-items)
+ * from the export directory results folder after a cancelled scan.
+ * The results folder itself is preserved (user may want partial artifacts).
  */
 const cleanUpExportDirCrawleeFiles = async (folderName) => {
   const userData = readUserDataFromFile()
@@ -792,7 +791,7 @@ const cleanUpExportDirCrawleeFiles = async (folderName) => {
   const exportResultsDir = path.join(userData.exportDir, folderName)
   if (!await fs.pathExists(exportResultsDir)) return
 
-  for (const dirName of ['datasets', 'request_queues', 'key_value_stores', 'tmp-items']) {
+  for (const dirName of ['crawlee', 'crawlee_rq', 'tmp-items']) {
     const dirPath = path.join(exportResultsDir, dirName)
     if (fs.existsSync(dirPath)) {
       await retryRemove(dirPath, `export ${dirName}`)


### PR DESCRIPTION
This reverts commit f96cfaaa32cb8b9106c9f7db9c0c7c517a3ba733.

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR -->

- [ ] I've kept this PR as small as possible (~500 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1 reviewer
- [ ] I've tested existing features (website scan, sitemap, custom flow)
- [ ] I've synced this fork with GovTechSG repo
- [ ] I've added/updated unit tests (N.A.)
- [ ] I've added/updated any necessary dependencies in `package[-lock].json` `npm audit`, portable installation on GitHub Actions
