### PR TITLE
security: harden update pipeline, TLS, XSS, IPC

### DIFF
--- a/.github/workflows/bump-package-version.yml
+++ b/.github/workflows/bump-package-version.yml
@@ -35,9 +35,18 @@ jobs:
 
       - name: Determine new version
         id: bump
+        env:
+          RAW_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
-            new_version=$(npm version "${{ github.event.inputs.version }}" --no-git-tag-version)
+          if [[ -n "$RAW_VERSION" ]]; then
+            # Only allow either a semver-ish literal (1.2.3, 1.2.3-beta.1) or
+            # one of the npm-version keywords. Anything else is a shell-metachar
+            # injection vector — reject early rather than passing to npm.
+            if [[ ! "$RAW_VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|major|minor|patch|premajor|preminor|prepatch|prerelease)$ ]]; then
+              echo "Invalid version input: $RAW_VERSION" >&2
+              exit 1
+            fi
+            new_version=$(npm version "$RAW_VERSION" --no-git-tag-version)
           else
             new_version=$(npm version patch --no-git-tag-version)
           fi

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -74,7 +74,7 @@ jobs:
         shell: pwsh
         run: |
           $hash = (Get-FileHash -Algorithm SHA256 oobee-desktop-windows.zip).Hash
-          [System.IO.File]::WriteAllText("oobee-desktop-windows.zip.sha256.txt", $hash)
+          [System.IO.File]::WriteAllText("oobee-desktop-windows.zip.sha256", $hash)
       
       - name: Upload Oobee Windows setup artifact
         uses: actions/upload-artifact@v4
@@ -82,7 +82,7 @@ jobs:
           name: oobee-desktop-windows
           path: |
             oobee-desktop-windows.zip
-            oobee-desktop-windows.zip.sha256.txt
+            oobee-desktop-windows.zip.sha256
         
       - name: Release Windows artifact
         uses: softprops/action-gh-release@v1
@@ -90,7 +90,7 @@ jobs:
         with:
           files: |
             oobee-desktop-windows.zip
-            oobee-desktop-windows.zip.sha256.txt
+            oobee-desktop-windows.zip.sha256
             
   mac-install-purple:
     runs-on: macos-latest
@@ -220,7 +220,7 @@ jobs:
       - name: Compute SHA256 hash for Mac
         run: |
           hash=$(shasum -a 256 oobee-desktop-macos.zip | awk '{ print $1 }')
-          printf "%s" "$hash" > oobee-desktop-macos.zip.sha256.txt
+          printf "%s" "$hash" > oobee-desktop-macos.zip.sha256
       
       - name: Upload Mac artifact
         uses: actions/upload-artifact@v4
@@ -228,7 +228,7 @@ jobs:
           name: oobee-desktop-macos
           path: |
             oobee-desktop-macos.zip
-            oobee-desktop-macos.zip.sha256.txt
+            oobee-desktop-macos.zip.sha256
           
       - name: Release Mac artifact
         uses: softprops/action-gh-release@v1
@@ -236,4 +236,4 @@ jobs:
         with:
           files: |
             oobee-desktop-macos.zip
-            oobee-desktop-macos.zip.sha256.txt
+            oobee-desktop-macos.zip.sha256

--- a/installer.ps1
+++ b/installer.ps1
@@ -8,7 +8,37 @@ $innoSetupCompilerUrl = "https://jrsoftware.org/download.php/is.exe"
 $innoSetupCompilerPath = "$env:APPDATA\iscc.exe"
 $current_path = (Get-Item -Path ".\" -Verbose).FullName
 
-Invoke-WebRequest -Uri $PHbackendUrl -OutFile $BEdestinationPath
+# Download an artifact and verify a SHA-256 hash published alongside it (as
+# <artifact>.sha256). Aborts the install if the hash file is missing or the
+# digest does not match — an attacker who tampers with the artifact would also
+# need to poison the .sha256, and if we ever gate the sidecar behind a signed
+# provenance channel this is the single place to plug it in.
+function Invoke-VerifiedDownload {
+    param(
+        [Parameter(Mandatory)][string]$ArtifactUrl,
+        [Parameter(Mandatory)][string]$OutFile
+    )
+    $hashUrl = "$ArtifactUrl.sha256"
+    $hashFile = "$OutFile.sha256"
+
+    Invoke-WebRequest -Uri $ArtifactUrl -OutFile $OutFile -UseBasicParsing
+    Invoke-WebRequest -Uri $hashUrl -OutFile $hashFile -UseBasicParsing
+
+    $expected = (Get-Content -Raw -Path $hashFile).Trim().Split()[0].ToLower()
+    if (-not $expected -or $expected.Length -ne 64) {
+        Remove-Item -Path $OutFile,$hashFile -Force -ErrorAction SilentlyContinue
+        throw "Refusing to install $ArtifactUrl : missing/invalid SHA-256 digest at $hashUrl"
+    }
+
+    $actual = (Get-FileHash -Path $OutFile -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) {
+        Remove-Item -Path $OutFile,$hashFile -Force -ErrorAction SilentlyContinue
+        throw "Refusing to install $ArtifactUrl : SHA-256 mismatch (expected $expected, got $actual)"
+    }
+    Remove-Item -Path $hashFile -Force -ErrorAction SilentlyContinue
+}
+
+Invoke-VerifiedDownload -ArtifactUrl $PHbackendUrl -OutFile $BEdestinationPath
 
 Expand-Archive -Path $BEdestinationPath -DestinationPath $BEextractPath -Force
 
@@ -16,7 +46,7 @@ Remove-Item -Path $BEdestinationPath
 
 echo "Oobee Backend extracted to $BEextractPath."
 
-Invoke-WebRequest -Uri $PHfrontendUrl -OutFile $FEdestinationPath
+Invoke-VerifiedDownload -ArtifactUrl $PHfrontendUrl -OutFile $FEdestinationPath
 
 Expand-Archive -Path $FEdestinationPath -DestinationPath $FEextractPath -Force
 

--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -1,27 +1,3 @@
-/**
- * Suppresses the "Setting the NODE_TLS_REJECT_UNAUTHORIZED 
- * environment variable to '0' is insecure" warning,
- * then disables TLS validation globally.
- */
-function suppressTlsRejectWarning() {
-  // Monkey-patch process.emitWarning
-  const originalEmitWarning = process.emitWarning;
-  process.emitWarning = (warning, ...args) => {
-    const msg = typeof warning === 'string' ? warning : warning.message;
-    if (msg.includes('NODE_TLS_REJECT_UNAUTHORIZED')) {
-      // swallow only that one warning
-      return;
-    }
-    // forward everything else
-    originalEmitWarning.call(process, warning, ...args);
-  };
-
-  // Now turn off cert validation
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-}
-// Allow Sentry to send data on proxied environments
-suppressTlsRejectWarning();
-
 const {
   app: electronApp,
   BrowserWindow,
@@ -69,8 +45,6 @@ function captureCmd(bin, args) {
 }
 
 const app = electronApp
-
-app.commandLine.appendSwitch('ignore-certificate-errors');
 
 // Initialize Sentry
 Sentry.init({
@@ -183,7 +157,7 @@ app.on('ready', async () => {
   const axiosInstance = axios.create({
     timeout: 5000,
     httpsAgent: new https.Agent({
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
       headers: {
         // 'X-Forwarded-For': 'xxx',
         'User-Agent': 'axios',
@@ -435,7 +409,19 @@ app.on('ready', async () => {
   })
 
   ipcMain.on('openLink', (_event, url) => {
-    shell.openExternal(url)
+    // Anything reachable through preload's contextBridge is renderer-controlled,
+    // so validate before shelling out to the OS. Only allow http/https/mailto —
+    // reject file://, javascript:, chrome-extension: etc. that could exec code
+    // or leak local files when passed to shell.openExternal.
+    if (typeof url !== 'string' || url.length === 0 || url.length > 4096) return
+    let parsed
+    try {
+      parsed = new URL(url)
+    } catch (e) {
+      return
+    }
+    if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) return
+    shell.openExternal(parsed.toString())
   })
 
   ipcMain.handle('getEngineVersion', () => {
@@ -485,9 +471,31 @@ app.on('ready', async () => {
 
   mainWindow.webContents.send('appStatus', 'ready')
 
+  // Strip tags / attributes / URL schemes that could execute JavaScript when
+  // the marked-rendered HTML is later assigned to innerHTML in the renderer.
+  // The release-notes catalog is remotely fetched, so treat its markdown as
+  // untrusted. Defense-in-depth: WhatsNewModal.jsx also allowlists tags on
+  // render, but sanitizing at the source stops <script>/<iframe> etc. from
+  // ever crossing the IPC boundary.
+  const sanitizeRenderedMarkdown = (html) => {
+    if (typeof html !== 'string' || html.length === 0) return ''
+    let out = html
+    // Drop entire dangerous elements (with their contents).
+    out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[\s\S]*?<\s*\/\s*\1\s*>/gi, '')
+    out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[^>]*>/gi, '')
+    // Drop inline event handlers (onclick=, onerror=, ...).
+    out = out.replace(/\s+on[a-z]+\s*=\s*"[^"]*"/gi, '')
+    out = out.replace(/\s+on[a-z]+\s*=\s*'[^']*'/gi, '')
+    out = out.replace(/\s+on[a-z]+\s*=\s*[^\s>]+/gi, '')
+    // Neutralize javascript:/vbscript:/data: URLs on href and src.
+    out = out.replace(/(\s(?:href|src|xlink:href)\s*=\s*")(\s*(?:javascript|vbscript|data)\s*:[^"]*)"/gi, '$1#"')
+    out = out.replace(/(\s(?:href|src|xlink:href)\s*=\s*')(\s*(?:javascript|vbscript|data)\s*:[^']*)'/gi, "$1#'")
+    return out
+  }
+
   const markdownToHTML = (md) => {
     if (typeof md !== 'string' || md.length === 0) return ''
-    return marked.parse(md)
+    return sanitizeRenderedMarkdown(marked.parse(md))
   }
 
   if (releaseInfo) {

--- a/public/electron/scanManager.js
+++ b/public/electron/scanManager.js
@@ -51,6 +51,45 @@ const sanitizeLogPath = (rawPath) => {
     .trim()
 }
 
+// Ensure ``candidate`` is a plain path that resolves inside one of the
+// app-controlled directories (appPath / resultsPath / scanResultsPath, plus
+// an OOBEE_LOGS_PATH override when the operator has set one). We derive the
+// error log path from scan-subprocess stdout; a malicious scan target could
+// in principle poison stdout with an absolute path pointing at an arbitrary
+// system file which would then be opened via shell.openPath. Reject anything
+// that escapes the allowlist or has an unexpected extension.
+const getAllowedLogRoots = () => {
+  const roots = [appPath, resultsPath, scanResultsPath]
+  if (process.env.OOBEE_LOGS_PATH) roots.push(process.env.OOBEE_LOGS_PATH)
+  return roots.filter(Boolean).map((r) => {
+    try { return path.resolve(r) } catch { return null }
+  }).filter(Boolean)
+}
+
+const isPathContainedIn = (candidate, root) => {
+  if (!candidate || !root) return false
+  const rel = path.relative(root, candidate)
+  // path.relative returns an absolute path when the two live on different
+  // Windows drives; treat that as "not contained".
+  if (path.isAbsolute(rel)) return false
+  // A leading '..' means the candidate escapes root via traversal.
+  return !rel.startsWith('..')
+}
+
+const isSafeErrorLogPath = (rawPath) => {
+  if (!rawPath || typeof rawPath !== 'string') return false
+  if (rawPath.length > 4096) return false
+  // Reject NUL bytes and any explicit remote-file scheme.
+  if (rawPath.includes('\0')) return false
+  const lowered = rawPath.trim().toLowerCase()
+  if (lowered.startsWith('file:') || lowered.startsWith('smb:') || lowered.startsWith('\\\\')) return false
+  let resolved
+  try { resolved = path.resolve(rawPath) } catch { return false }
+  const ext = path.extname(resolved).toLowerCase()
+  if (ext !== '.txt' && ext !== '.log') return false
+  return getAllowedLogRoots().some((root) => isPathContainedIn(resolved, root))
+}
+
 const killChildProcess = () => {
   if (currentChildProcess) {
     const proc = currentChildProcess
@@ -435,10 +474,13 @@ const startScan = async (scanDetails, scanEvent) => {
           const prefix = 'Logger writing to: '
           const index = message.indexOf(prefix)
           if (index !== -1) {
-            process.env.OOBEE_ERROR_LOG_PATH = message
-              .substring(index + prefix.length)
-              .trim()
-            console.log('Error log path set to:\n', process.env.OOBEE_ERROR_LOG_PATH)
+            const candidate = message.substring(index + prefix.length).trim()
+            if (isSafeErrorLogPath(candidate)) {
+              process.env.OOBEE_ERROR_LOG_PATH = candidate
+              console.log('Error log path set to:\n', process.env.OOBEE_ERROR_LOG_PATH)
+            } else {
+              console.warn('Rejected out-of-scope error log path from stdout')
+            }
           }
         } catch (error) {
           console.error('Failed to parse log data as JSON:', error)
@@ -449,9 +491,11 @@ const startScan = async (scanDetails, scanEvent) => {
         const match = trimmedLine.match(
           /An error occured\. Log file is located at:\s*(\S+?\.txt)(?=\s|$)/
         )
-        if (match && match[1]) {
+        if (match && match[1] && isSafeErrorLogPath(match[1])) {
           process.env.OOBEE_ERROR_LOG_PATH = match[1]
           console.log('Error log path changed to:\n', process.env.OOBEE_ERROR_LOG_PATH)
+        } else if (match && match[1]) {
+          console.warn('Rejected out-of-scope error log path from error message')
         }
         resolveOnce({ success: false })
         return
@@ -783,7 +827,15 @@ const init = (scanEvent) => {
   ipcMain.handle(
     'getErrorLog',
     async (event, timeOfScanString, timeOfError) => {
-      const errorLogPath = process.env.OOBEE_ERROR_LOG_PATH || path.join(appPath, 'errors.txt');
+      // Fall back to the vetted default when OOBEE_ERROR_LOG_PATH points at
+      // something outside the app-controlled log roots. Defense in depth:
+      // isSafeErrorLogPath already runs at the stdout ingestion sites, but
+      // OOBEE_ERROR_LOG_PATH is a plain process env var that any code in
+      // this process could set, so we re-check at the read/open site too.
+      const envPath = process.env.OOBEE_ERROR_LOG_PATH
+      const errorLogPath = (envPath && isSafeErrorLogPath(envPath))
+        ? envPath
+        : path.join(appPath, 'errors.txt')
       const errorLog = fs.readFileSync(errorLogPath, 'utf-8')
       const regex = /{.*?}/gs
       const entries = errorLog.match(regex)
@@ -828,7 +880,13 @@ const init = (scanEvent) => {
   )
 
   ipcMain.handle('openErrorLog', async () => {
-    const errorLogPath = process.env.OOBEE_ERROR_LOG_PATH || path.join(appPath, 'errors.txt')
+    // Re-validate at the shell.openPath sink: if OOBEE_ERROR_LOG_PATH has
+    // been mutated to point outside the app-controlled log roots, fall
+    // back to the safe default rather than opening an arbitrary file.
+    const envPath = process.env.OOBEE_ERROR_LOG_PATH
+    const errorLogPath = (envPath && isSafeErrorLogPath(envPath))
+      ? envPath
+      : path.join(appPath, 'errors.txt')
     if (!fs.existsSync(errorLogPath)) {
       return { success: false, reason: 'not-found' }
     }

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -2,7 +2,46 @@ const os = require("os");
 const path = require("path");
 const fs = require("fs");
 const crypto = require("crypto");
+const https = require("https");
 const { exec, spawn } = require("child_process");
+
+// Download a `<artifactUrl>.sha256` sidecar (over verified TLS) and match it
+// against the actual SHA-256 of the on-disk artifact. Any failure — network
+// error, missing sidecar, malformed digest, mismatch — throws, so the caller
+// aborts install rather than extracting an unverified zip. The sidecar file
+// content is expected to be a single 64-char hex digest, optionally followed
+// by whitespace and a filename (shasum -a 256 output format).
+const verifyArtifactSha256 = (artifactUrl, artifactPath) => new Promise((resolve, reject) => {
+  const hashUrl = `${artifactUrl}.sha256`;
+  const req = https.get(hashUrl, { timeout: 15000 }, (res) => {
+    if (res.statusCode !== 200) {
+      res.resume();
+      return reject(new Error(`Missing SHA-256 sidecar at ${hashUrl} (HTTP ${res.statusCode})`));
+    }
+    let body = "";
+    res.setEncoding("utf8");
+    res.on("data", (chunk) => { body += chunk; if (body.length > 4096) req.destroy(new Error("sha256 sidecar too large")); });
+    res.on("end", () => {
+      const expected = (body.trim().split(/\s+/)[0] || "").toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(expected)) {
+        return reject(new Error(`Invalid SHA-256 digest at ${hashUrl}`));
+      }
+      const hash = crypto.createHash("sha256");
+      const stream = fs.createReadStream(artifactPath);
+      stream.on("error", reject);
+      stream.on("data", (d) => hash.update(d));
+      stream.on("end", () => {
+        const actual = hash.digest("hex");
+        if (actual !== expected) {
+          return reject(new Error(`SHA-256 mismatch on ${artifactPath}: expected ${expected}, got ${actual}`));
+        }
+        resolve();
+      });
+    });
+  });
+  req.on("timeout", () => req.destroy(new Error(`Timed out fetching ${hashUrl}`)));
+  req.on("error", reject);
+});
 const {
   getFrontendVersion,
   getEngineVersion,
@@ -25,6 +64,52 @@ const {
 let currentChildProcess;
 let isLabMode = false;
 let powershellAvailable = null;
+
+// Values under this module's control get interpolated into shell / PowerShell
+// scripts and macOS admin AppleScript. The `baseUrl`, `tag`, `macAppName`,
+// `macZipName`, `windowsZipName`, and `windowsInstallerName` fields all flow
+// from the remotely-fetched release catalog (latest-release.json). Treat those
+// as untrusted and reject anything outside an allowlist before it can reach
+// bash `-c` / powershell `-Command` / osascript `do shell script`.
+
+// Only allow the two GovTechSG repos we ship from. Any redirect target the
+// catalog claims still has to match one of these — otherwise an attacker who
+// mutates the JSON (e.g. via MITM before TLS was fixed, or by taking over the
+// docs origin) could point the client at their own release zip.
+const ALLOWED_BASE_URLS = new Set([
+  "https://github.com/GovTechSG/oobee-desktop",
+  "https://github.com/GovTechSG/oobee",
+]);
+// Version tag: allow the release-line pattern (with optional v prefix, plus
+// optional pre-release suffix like -beta.1). Deliberately narrow so it can't
+// carry shell metacharacters.
+const TAG_RE = /^v?\d+(?:\.\d+){0,3}(?:-[A-Za-z0-9._-]+)?$/;
+// Asset filenames: letters, digits, dot, dash, underscore. No slashes, spaces,
+// or shell metacharacters. macAppName ends with `.app`.
+const ASSET_ZIP_RE = /^[A-Za-z0-9._-]{1,128}\.zip$/;
+const ASSET_EXE_RE = /^[A-Za-z0-9._-]{1,128}\.exe$/;
+const ASSET_APP_RE = /^[A-Za-z0-9._-]{1,128}\.app$/;
+
+const validateBaseUrl = (v) => {
+  if (v === undefined || v === null || v === "") return undefined;
+  if (typeof v !== "string" || !ALLOWED_BASE_URLS.has(v)) {
+    throw new Error(`Rejecting untrusted baseUrl: ${v}`);
+  }
+  return v;
+};
+const validateTag = (v) => {
+  if (typeof v !== "string" || !TAG_RE.test(v)) {
+    throw new Error(`Rejecting untrusted tag: ${v}`);
+  }
+  return v;
+};
+const validateAssetName = (v, re, kind) => {
+  if (v === undefined || v === null || v === "") return undefined;
+  if (typeof v !== "string" || !re.test(v)) {
+    throw new Error(`Rejecting untrusted ${kind}: ${v}`);
+  }
+  return v;
+};
 
 function checkPowerShellAvailable() {
   if (powershellAvailable !== null) return powershellAvailable; // cache result
@@ -201,29 +286,54 @@ const getLatestFrontendVersion = (latestRelease, latestPreRelease) => {
  * @returns {Promise<void>} void if the frontend was downloaded and unzipped successfully
  */
 const downloadAndUnzipFrontendWindows = async (tag, baseUrl = undefined, windowsZipName = undefined, windowsInstallerName = undefined) => {
+  // The tag / baseUrl / asset-name fields all flow from the remote release
+  // catalog, and the download URL and the PowerShell script are built by
+  // string interpolation. Validate up front so a hostile catalog can't inject
+  // `"; Invoke-Expression ...` payloads.
+  const safeTag = validateTag(tag);
+  const safeBaseUrl = validateBaseUrl(baseUrl) || "https://github.com/GovTechSG/oobee-desktop";
   // Remote asset name from latest-release.json — lets a future release rename
   // the zip (e.g. new repo with a different asset naming scheme).
-  const remoteZipName = windowsZipName || "oobee-desktop-windows.zip";
-  const installerName = windowsInstallerName || "Oobee-setup.exe";
+  const remoteZipName = validateAssetName(windowsZipName, ASSET_ZIP_RE, "windowsZipName") || "oobee-desktop-windows.zip";
+  const installerName = validateAssetName(windowsInstallerName, ASSET_EXE_RE, "windowsInstallerName") || "Oobee-setup.exe";
 
-  const downloadUrl = `${baseUrl || "https://github.com/GovTechSG/oobee-desktop"}/releases/download/${tag}/${remoteZipName}`;
+  const downloadUrl = `${safeBaseUrl}/releases/download/${safeTag}/${remoteZipName}`;
 
   // Local paths are internal — keep stable names so we don't churn folder layout.
   const localZipPath = `${resultsPath}\\oobee-desktop-windows.zip`;
   const extractDir = `${resultsPath}\\oobee-desktop-windows`;
   const installerPath = path.join(extractDir, installerName);
 
+  // Download the sidecar (`<downloadUrl>.sha256`) alongside the artifact and
+  // compare the digests before Expand-Archive runs. If either the sidecar
+  // is missing/malformed or the hashes don't match, PowerShell exits 3 and
+  // the caller aborts install — matching the enforcement in installer.ps1.
   const shellScript = `
+  $ErrorActionPreference = "Stop"
   $webClient = New-Object System.Net.WebClient
   try {
     If (!(Test-Path -Path "${resultsPath}")) {
       New-Item -ItemType Directory -Path "${resultsPath}"
     }
     $webClient.DownloadFile("${downloadUrl}", "${localZipPath}")
+    $webClient.DownloadFile("${downloadUrl}.sha256", "${localZipPath}.sha256")
   } catch {
     Write-Host "Error: Unable to download frontend"
     throw "Unable to download frontend"
     exit 1
+  }
+
+  try {
+    $expected = (Get-Content -Raw -Path "${localZipPath}.sha256").Trim().Split()[0].ToLower()
+    if (-not $expected -or $expected.Length -ne 64) { throw "Invalid SHA-256 sidecar" }
+    $actual = (Get-FileHash -Path "${localZipPath}" -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) { throw "SHA-256 mismatch: expected $expected got $actual" }
+    Remove-Item -Path "${localZipPath}.sha256" -Force -ErrorAction SilentlyContinue
+  } catch {
+    Write-Host "Error: Frontend integrity check failed"
+    Remove-Item -Path "${localZipPath}","${localZipPath}.sha256" -Force -ErrorAction SilentlyContinue
+    throw "Frontend integrity check failed"
+    exit 3
   }
 
   try {
@@ -266,18 +376,23 @@ const downloadAndUnzipFrontendWindows = async (tag, baseUrl = undefined, windows
  * Spawns a Shell Command process to download and unzip the frontend
  */
 const downloadAndUnzipFrontendMac = async (tag, baseUrl = undefined, macAppName = undefined, macZipName = undefined) => {
+  // Same rationale as downloadAndUnzipFrontendWindows: every string that flows
+  // into the download URL or the shell / osascript install command comes from
+  // the remote release catalog. Validate up front so a hostile catalog value
+  // like `x'; rm -rf ~; :'.zip` can't reach bash.
+  const safeTag = validateTag(tag);
+  const safeBaseUrl = validateBaseUrl(baseUrl) || "https://github.com/GovTechSG/oobee-desktop";
   // Remote asset name from latest-release.json so a future release can rename
   // the zip asset (e.g. when moving to a new repo with different naming).
-  const remoteZipName = macZipName || "oobee-desktop-macos.zip";
-  const downloadUrl = `${baseUrl || "https://github.com/GovTechSG/oobee-desktop"}/releases/download/${tag}/${remoteZipName}`;
+  const remoteZipName = validateAssetName(macZipName, ASSET_ZIP_RE, "macZipName") || "oobee-desktop-macos.zip";
+  const downloadUrl = `${safeBaseUrl}/releases/download/${safeTag}/${remoteZipName}`;
 
   const parentDir = path.join(macOSExecutablePath, "..");
 
   // Path of the freshly-extracted .app. `macAppName` comes from latest-release.json
   // so a future release can rename the bundle (e.g. "Oobee Scanner.app") without a
   // client rebuild — the zip's top-level directory just has to match this name.
-  // Spaces are safe because every shell interpolation below is single-quoted.
-  const newAppName = macAppName || "Oobee.app";
+  const newAppName = validateAssetName(macAppName, ASSET_APP_RE, "macAppName") || "Oobee.app";
   const newAppPath = path.join(parentDir, newAppName);
 
   // `curl -fL`: `-f` makes curl exit non-zero on HTTP 4xx/5xx instead of writing
@@ -303,6 +418,19 @@ const downloadAndUnzipFrontendMac = async (tag, baseUrl = undefined, macAppName 
   const installCommand = `{ [ ! -e '${macOSExecutablePath}' ] || mv '${macOSExecutablePath}' '${parentDir}/${tempAppName}'; } && ditto -xk '${localZipPath}' '${parentDir}' && rm -f '${localZipPath}' && rm -rf '${parentDir}/${tempAppName}' && (xattr -rd com.apple.quarantine '${newAppPath}' 2>/dev/null || true)`;
 
   await execCommand(downloadCommand);
+
+  // Verify the downloaded zip against the SHA-256 sidecar published alongside
+  // the artifact BEFORE any elevation prompt fires. If the sidecar is missing
+  // or the hashes disagree, throw so we do not run ditto (which would extract
+  // an unverified bundle into /Applications) or trigger an admin prompt on
+  // behalf of an attacker-supplied zip.
+  try {
+    await verifyArtifactSha256(downloadUrl, localZipPath);
+    consoleLogger.info(`Integrity check passed for ${downloadUrl}`);
+  } catch (err) {
+    try { fs.unlinkSync(localZipPath); } catch (_) {}
+    throw new Error(`Frontend integrity check failed: ${err.message}`);
+  }
 
   // Try unprivileged first. If it fails for any reason (POSIX denial, MDM/Admin
   // By Request policy, SIP, etc.), fall back to the elevated path which triggers
@@ -349,7 +477,7 @@ const downloadAndUnzipFrontendMac = async (tag, baseUrl = undefined, macAppName 
     }
 
     // `tag` may be prefixed with "v" (e.g. "v0.11.2"); Info.plist stores the bare version.
-    const expected = tag.replace(/^v/, "");
+    const expected = safeTag.replace(/^v/, "");
     if (installedVersion !== expected) {
       throw new Error(
         `Update verification failed: expected version ${expected} but installed bundle reports ${installedVersion}`

--- a/public/electron/userDataManager.js
+++ b/public/electron/userDataManager.js
@@ -156,7 +156,19 @@ const init = async () => {
             console.error('openResultsFolder received an invalid path');
             return;
         }
-        shell.openPath(path.normalize(safeResultsPath));
+
+        // Confine the path to the configured export directory (or the default)
+        // so a renderer-side XSS / malformed IPC payload can't drive shell.openPath
+        // to launch arbitrary local files with their OS default handler.
+        const userData = readUserDataFromFile();
+        const exportRoot = path.resolve(userData.exportDir || defaultExportDir);
+        const target = path.resolve(exportRoot, safeResultsPath);
+        const rel = path.relative(exportRoot, target);
+        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+            console.error('openResultsFolder rejected: path escapes exportDir', { target, exportRoot });
+            return;
+        }
+        shell.openPath(target);
     })
 }
 

--- a/public/electron/userDataManager.js
+++ b/public/electron/userDataManager.js
@@ -47,9 +47,32 @@ const setIncludeProxy = (includeProxyValue) => {
     return { success: true };
 }
 
+// Only these keys may be updated by editUserData / writeUserDetailsToFile. The
+// data payload is renderer-controlled (arrives via ipcMain.on('editUserData')),
+// so a `{...userData, ...data}` spread would let it overwrite server-managed
+// fields (userId, autoUpdate, exportDir, etc.). Keep this list in sync with
+// fields written elsewhere by the main process.
+const USER_DATA_WRITABLE_FIELDS = new Set([
+    'name',
+    'email',
+    'browser',
+    'event',
+    'autoUpdate',
+    'isLabMode',
+    'firstLaunchOnUpdate',
+]);
+
 const writeUserDetailsToFile = (data) => {
     const userData = readUserDataFromFile();
-    const updatedData = { ...userData, ...data };
+    const clean = {};
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+        for (const key of Object.keys(data)) {
+            if (USER_DATA_WRITABLE_FIELDS.has(key)) {
+                clean[key] = data[key];
+            }
+        }
+    }
+    const updatedData = { ...userData, ...clean };
     fs.writeFileSync(userDataFilePath, JSON.stringify(updatedData));
 
     Sentry.setUser({

--- a/scripts/downloadAndUnzipBackend.ps1
+++ b/scripts/downloadAndUnzipBackend.ps1
@@ -1,5 +1,17 @@
 $backendTag = $args[0];
 
+# Reject any tag value that does not match a strict version/tag allowlist.
+# The tag is interpolated into a here-string that is later executed by an
+# elevated PowerShell process, so a value containing quotes, semicolons,
+# backticks, or newlines would land as executable code in that elevated
+# session. Restrict to characters that legitimately appear in oobee release
+# tags (letters, digits, '.', '_', '-') and cap the length so runaway input
+# cannot slip through.
+if ([string]::IsNullOrWhiteSpace($backendTag) -or $backendTag.Length -gt 64 -or ($backendTag -notmatch '^[A-Za-z0-9._-]+$')) {
+    Write-Error "Rejected backend tag: value must match ^[A-Za-z0-9._-]+$ and be <=64 chars."
+    exit 1
+}
+
 $purpleA11yDirectory = 'C:\Program Files\Oobee Desktop';
 $purpleA11yBackendDirectory = 'C:\Program Files\Oobee Desktop\Oobee Backend';
 $purpleA11yBackendPHDirectory = 'C:\Program Files\Oobee Desktop\Oobee Backend\oobee';

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -18,6 +18,10 @@ const HTML_TO_REACT_ATTR = {
 const ALLOWED_TAGS = new Set([
   "a","p","br","hr","strong","em","b","i","u","code","pre",
   "h1","h2","h3","h4","h5","h6","ul","ol","li","blockquote","span","div",
+  // Markdown-authored release notes commonly embed screenshots/badges via
+  // ![alt](url), which marked converts to <img>. Keep it in the allowlist so
+  // those images survive sanitization; src is validated through isSafeHref.
+  "img",
 ]);
 const ALLOWED_ATTRS_BY_TAG = {
   a: new Set(["href","title"]),
@@ -25,6 +29,7 @@ const ALLOWED_ATTRS_BY_TAG = {
   pre: new Set(["class"]),
   span: new Set(["class"]),
   div: new Set(["class"]),
+  img: new Set(["src","alt","title","width","height"]),
 };
 const SAFE_URL_SCHEMES = /^(https?:|mailto:)/i;
 
@@ -50,7 +55,7 @@ const htmlNodeToReact = (node, key) => {
     const rawName = attr.name.toLowerCase();
     if (rawName.startsWith("on")) continue;
     if (!allowedAttrs.has(rawName)) continue;
-    if (rawName === "href" && !isSafeHref(attr.value)) continue;
+    if ((rawName === "href" || rawName === "src") && !isSafeHref(attr.value)) continue;
     const name = HTML_TO_REACT_ATTR[rawName] || rawName;
     props[name] = attr.value;
   }

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -11,6 +11,30 @@ const HTML_TO_REACT_ATTR = {
   for: "htmlFor",
 };
 
+// Release notes / announcements come from a remotely-fetched release catalog,
+// so treat the HTML as untrusted. Only these tags/attributes survive parsing;
+// everything else (scripts, iframes, event handlers, javascript: hrefs) is
+// dropped before it can reach React.createElement.
+const ALLOWED_TAGS = new Set([
+  "a","p","br","hr","strong","em","b","i","u","code","pre",
+  "h1","h2","h3","h4","h5","h6","ul","ol","li","blockquote","span","div",
+]);
+const ALLOWED_ATTRS_BY_TAG = {
+  a: new Set(["href","title"]),
+  code: new Set(["class"]),
+  pre: new Set(["class"]),
+  span: new Set(["class"]),
+  div: new Set(["class"]),
+};
+const SAFE_URL_SCHEMES = /^(https?:|mailto:)/i;
+
+const isSafeHref = (v) => {
+  if (typeof v !== "string") return false;
+  const s = v.trim();
+  if (s.startsWith("/") || s.startsWith("#")) return true;
+  return SAFE_URL_SCHEMES.test(s);
+};
+
 // Walk an HTML DOM node and produce a React element tree. Every <a href>
 // gets the external-link icon appended as an extra child so hyperlinks in
 // markdown-authored release notes / announcements have the same visual
@@ -19,9 +43,15 @@ const htmlNodeToReact = (node, key) => {
   if (node.nodeType === Node.TEXT_NODE) return node.textContent;
   if (node.nodeType !== Node.ELEMENT_NODE) return null;
   const tag = node.tagName.toLowerCase();
+  if (!ALLOWED_TAGS.has(tag)) return null;
+  const allowedAttrs = ALLOWED_ATTRS_BY_TAG[tag] || new Set();
   const props = { key };
   for (const attr of node.attributes) {
-    const name = HTML_TO_REACT_ATTR[attr.name] || attr.name;
+    const rawName = attr.name.toLowerCase();
+    if (rawName.startsWith("on")) continue;
+    if (!allowedAttrs.has(rawName)) continue;
+    if (rawName === "href" && !isSafeHref(attr.value)) continue;
+    const name = HTML_TO_REACT_ATTR[rawName] || rawName;
     props[name] = attr.value;
   }
   const children = Array.from(node.childNodes).map((c, i) => htmlNodeToReact(c, i));
@@ -108,7 +138,8 @@ const WhatsNewModal = ({
             // matches "See previous versions" and the announcement anchors.
             // The parent modal-body div has a delegated click handler that
             // intercepts the click and routes it through shell.openExternal.
-            const href = child.getAttribute("href");
+            const rawHref = child.getAttribute("href");
+            const href = isSafeHref(rawHref) ? rawHref : "#";
             liChildElems.push(
               createElement(
                 "a",

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -130,7 +130,19 @@ export const installChromeUrl = `https://www.google.com/chrome/?brand=CHBD&brand
 
 export const handleClickLink = (e, url) => {
   e.preventDefault()
-  window.services.openLink(url)
+  // Release-notes / announcement HTML is fetched from a remote catalog, so
+  // anchor hrefs are not fully trusted. Only allow http/https/mailto here —
+  // the main-process ipcMain.on('openLink') handler enforces the same
+  // allowlist as a second layer.
+  if (typeof url !== 'string' || url.length === 0 || url.length > 4096) return
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch (err) {
+    return
+  }
+  if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) return
+  window.services.openLink(parsed.toString())
 }
 
 export const forbiddenCharactersInDirPath = [


### PR DESCRIPTION
## Summary

Remediates findings from the asgard cybersecurity scan (`~/oobee-v2-cybersecurity-report/oobee-desktop/`).

### High-severity fixes (commit `a4ec7f0`, compat fixups in `d9094ab`)

- **asgard-0001 (update integrity)** — fetch `<artifactUrl>.sha256` sidecar and verify SHA-256 before extract/launch on Mac, Windows, and inside `installer.ps1`.
- **asgard-0002 / 0007 (shell / PowerShell injection)** — validate `baseUrl` (allowlist to two GovTechSG repos), `tag` (semver-ish regex), and Mac / Windows asset names against strict regexes before they can reach `exec`/`spawn` interpolation.
- **asgard-0003 (contextBridge exposure)** — validate the `openLink` URL through `new URL()` in main and reject anything outside `http`/`https`/`mailto`.
- **asgard-0004 (WhatsNewModal DOM XSS)** — allowlist tags / attributes / URL schemes when walking release-notes HTML; drop event handlers and non-http(s) hrefs before they reach `React.createElement`. `<img>` is retained in the allowlist so markdown screenshots survive; `src` is validated through `isSafeHref`.
- **asgard-0005 (global TLS disabled)** — remove `suppressTlsRejectWarning()`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `ignore-certificate-errors` switch, and flip axios `rejectUnauthorized` back to true.
- **asgard-0006 (marked.parse XSS)** — sanitize rendered HTML in `main.js` before sending over IPC — strip `<script>`, `<style>`, `<iframe>`, etc., inline event handlers, and `javascript:` / `vbscript:` / `data:` URLs.
- **asgard-0008 (installer.ps1 integrity)** — `Invoke-VerifiedDownload` wraps `Invoke-WebRequest` with SHA-256 sidecar verification; aborts if missing.
- **asgard-0009 (mass assignment in `writeUserDetailsToFile`)** — allowlist the fields renderer-supplied `editUserData` payloads may set.

### Medium / low fixes (commit `216855d`)

- **asgard-0010 (bump-package-version workflow injection)** — pipe the `workflow_dispatch` `version` input through an `env:` var and validate it against a semver-or-keyword allowlist before it reaches `npm version "$RAW_VERSION"`.
- **asgard-0011 (renderer `openLink` allowlist)** — validate the anchor href via `URL()` in `handleClickLink` before forwarding to `window.services.openLink`.
- **asgard-0012 (`openResultsFolder` path escape)** — resolve the renderer-supplied path against the configured `exportDir` and reject any target that escapes it.

### Info-level fixes (commit `d3c9d7a`)

- **asgard-0013 (PowerShell tag injection)** — reject `$backendTag` values that fall outside `^[A-Za-z0-9._-]+$` (or exceed 64 chars) before interpolating them into the elevated `-Command` here-string in `downloadAndUnzipBackend.ps1`.
- **asgard-0014 (stdout-derived error log path)** — validate the scan-subprocess stdout-derived `OOBEE_ERROR_LOG_PATH` against an allowlist of app-controlled log roots (`appPath` / `resultsPath` / `scanResultsPath`, plus operator-set `OOBEE_LOGS_PATH`) with `.txt` or `.log` extension before letting it drive `fs.readFileSync` or `shell.openPath`; re-checked at both consumer sites, malformed candidates fall back to the vetted default under `appPath`.
- **asgard-0015 (openExternal URL allowlist)** — already addressed by the asgard-0003 fix in the initial high-severity commit; the current `openLink` handler validates the URL through `new URL()` and only allows `http:` / `https:` / `mailto:`.

## Compat regressions from the hardening (fixed in this branch)

- `.sha256` sidecar filename was `.sha256.txt` in `image.yml` but `.sha256` on the client — renamed to match. Every in-app update would otherwise have hard-failed with 'Missing SHA-256 sidecar'.
- `<img>` was dropped from the release-notes allowlist. Every screenshot/badge in the What's New modal would have silently disappeared. Added `img` (`src` / `alt` / `title` / `width` / `height`) to the allowlist with `src` validated through `isSafeHref`.

Requires companion oobee PR to publish `oobee-portable-{windows,mac}.zip.sha256` sidecars, otherwise `installer.ps1` will fail on first run.

## Test plan

- [ ] Cut a test release; confirm both `oobee-desktop-*.zip.sha256` sidecars are present
- [ ] Trigger an in-app update; downloadedAndUnzip path succeeds against a good hash and fails cleanly against a poisoned hash
- [ ] Run `installer.ps1` end-to-end on Windows against a release that includes the portable oobee `.sha256`
- [ ] Open What's New modal for a release whose notes contain images, code blocks, and external links; images render, event handlers are stripped, `javascript:` links are dropped
- [ ] Fetch release catalog over TLS with a known-bad cert; request fails (TLS verification enabled)
- [ ] Attempt renderer-side mass-assignment on `writeUserDetailsToFile`; only allowlisted fields survive
- [ ] Invoke `downloadAndUnzipBackend.ps1` with a malformed tag argument (e.g. `foo;calc`); script errors out before interpolation
- [ ] Set `OOBEE_ERROR_LOG_PATH` to `/etc/passwd`; `openErrorLog` falls back to the default under `appPath` rather than opening the target

🤖 Generated with [Claude Code](https://claude.com/claude-code)