### PR TITLE
fix(updater): follow 302 redirects when fetching SHA-256 sidecar on macOS

### DIFF
--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -11,20 +11,34 @@ const { exec, spawn } = require("child_process");
 // aborts install rather than extracting an unverified zip. The sidecar file
 // content is expected to be a single 64-char hex digest, optionally followed
 // by whitespace and a filename (shasum -a 256 output format).
+//
+// GitHub release-asset URLs (github.com/.../releases/download/...) always
+// respond with HTTP 302 to a short-lived release-assets.githubusercontent.com
+// URL. Node's `https.get` does not auto-follow redirects, so we walk up to
+// MAX_REDIRECTS hops manually. Each hop must remain on https:// — a downgrade
+// to http would let a network attacker who can rewrite Location: hand us an
+// attacker-controlled sidecar with a matching (attacker-picked) hash.
 const verifyArtifactSha256 = (artifactUrl, artifactPath) => new Promise((resolve, reject) => {
-  const hashUrl = `${artifactUrl}.sha256`;
-  const req = https.get(hashUrl, { timeout: 15000 }, (res) => {
-    if (res.statusCode !== 200) {
-      res.resume();
-      return reject(new Error(`Missing SHA-256 sidecar at ${hashUrl} (HTTP ${res.statusCode})`));
-    }
+  const MAX_REDIRECTS = 5;
+  const originalHashUrl = `${artifactUrl}.sha256`;
+
+  const consumeBody = (res) => {
     let body = "";
+    let aborted = false;
     res.setEncoding("utf8");
-    res.on("data", (chunk) => { body += chunk; if (body.length > 4096) req.destroy(new Error("sha256 sidecar too large")); });
+    res.on("data", (chunk) => {
+      if (aborted) return;
+      body += chunk;
+      if (body.length > 4096) {
+        aborted = true;
+        res.destroy(new Error("sha256 sidecar too large"));
+      }
+    });
     res.on("end", () => {
+      if (aborted) return;
       const expected = (body.trim().split(/\s+/)[0] || "").toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(expected)) {
-        return reject(new Error(`Invalid SHA-256 digest at ${hashUrl}`));
+        return reject(new Error(`Invalid SHA-256 digest at ${originalHashUrl}`));
       }
       const hash = crypto.createHash("sha256");
       const stream = fs.createReadStream(artifactPath);
@@ -38,9 +52,39 @@ const verifyArtifactSha256 = (artifactUrl, artifactPath) => new Promise((resolve
         resolve();
       });
     });
-  });
-  req.on("timeout", () => req.destroy(new Error(`Timed out fetching ${hashUrl}`)));
-  req.on("error", reject);
+    res.on("error", reject);
+  };
+
+  const fetch = (currentUrl, redirectsLeft) => {
+    const req = https.get(currentUrl, { timeout: 15000 }, (res) => {
+      const { statusCode, headers } = res;
+      if (statusCode >= 300 && statusCode < 400 && headers.location) {
+        res.resume();
+        if (redirectsLeft <= 0) {
+          return reject(new Error(`Too many redirects fetching ${originalHashUrl}`));
+        }
+        let nextUrl;
+        try {
+          nextUrl = new URL(headers.location, currentUrl).toString();
+        } catch (e) {
+          return reject(new Error(`Invalid redirect target for ${originalHashUrl}: ${headers.location}`));
+        }
+        if (!nextUrl.startsWith("https://")) {
+          return reject(new Error(`Refusing non-https redirect from ${originalHashUrl} to ${nextUrl}`));
+        }
+        return fetch(nextUrl, redirectsLeft - 1);
+      }
+      if (statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`Missing SHA-256 sidecar at ${originalHashUrl} (HTTP ${statusCode})`));
+      }
+      consumeBody(res);
+    });
+    req.on("timeout", () => req.destroy(new Error(`Timed out fetching ${originalHashUrl}`)));
+    req.on("error", reject);
+  };
+
+  fetch(originalHashUrl, MAX_REDIRECTS);
 });
 const {
   getFrontendVersion,


### PR DESCRIPTION
## Summary
- Every macOS in-app update since [246b33b](https://github.com/GovTechSG/oobee-desktop/commit/246b33b) (asgard-0001 hardening) hard-fails with `Missing SHA-256 sidecar (HTTP 302)` because Node's `https.get` does not auto-follow redirects, while GitHub release-asset URLs always return 302 to `release-assets.githubusercontent.com`.
- `verifyArtifactSha256` now walks up to 5 redirect hops manually and refuses any hop that isn't `https://` (a downgrade would let an on-path attacker rewrite `Location:` to their own sidecar with an attacker-picked hash and defeat the whole integrity check).
- The zip download itself was fine — `curl -fL` follows redirects. Only the sidecar check was broken. Symptom users saw: "update downloads then fails to extract, app reopens on the old version." The install command never runs; the catch in `run()` emits `frontendDownloadFailed` and the caller falls through.

## Test plan
- [x] Reproduced the failure locally against `https://github.com/GovTechSG/oobee-desktop/releases/download/0.11.17/oobee-desktop-macos.zip.sha256` with the unfixed function — `Missing SHA-256 sidecar (HTTP 302)`.
- [x] With the patched function against the same URL — sidecar fetched (via 302 hop) and SHA-256 of the on-disk 576 MB zip matches `de885e7402207e722f91e847ec1aefc2b0f59649ff4be26c9daf29496057e07e`.
- [ ] End-to-end: build 0.11.15, install a newer tag on the release catalog, click Update, confirm the extract runs and the app relaunches on the new version.
- [ ] Verify the non-https redirect guard rejects a `Location: http://...` response (integrity-check regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)