### PR TITLE
security: parse release-notes HTML inertly and close sanitizer quote-abut bypass

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -507,25 +507,32 @@ app.on('ready', async () => {
   //
   // HTML allows any of whitespace, `/`, or `=` following an attribute name,
   // so `\s+on...` alone is bypassable (e.g. `<img/onerror=alert(1) src=x>`).
-  // The event-handler and URL-scheme regexes below treat `[\s/]` as valid
-  // attribute separators before the attribute name.
+  // Additionally, the HTML tokenizer treats a letter directly after a
+  // quoted attribute value as the start of a NEW attribute — a parse
+  // error the tokenizer recovers from by creating the attribute anyway.
+  // So `<img src="x"onerror=...>` (quote abutting the next attribute
+  // name, with no whitespace) must also be caught. The `ATTR_SEP` class
+  // below therefore includes `"` and `'`; we preserve the captured
+  // separator via `$1` so we don't consume the value-terminating quote
+  // of the preceding attribute.
+  const ATTR_SEP = '["\'\\s/]'
   const sanitizeRenderedMarkdown = (html) => {
     if (typeof html !== 'string' || html.length === 0) return ''
     let out = html
     // Drop entire dangerous elements (with their contents).
     out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[\s\S]*?<\s*\/\s*\1\s*>/gi, '')
     out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[^>]*>/gi, '')
-    // Drop inline event handlers (onclick=, onerror=, ...). Match `/` or
-    // whitespace as the separator between the previous attribute/tag and
-    // the `on*` attribute name so `<img/onerror=...>` is also caught.
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*"[^"]*"/gi, ' ')
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*'[^']*'/gi, ' ')
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*[^\s>]+/gi, ' ')
+    // Drop inline event handlers (onclick=, onerror=, ...). Preserve the
+    // captured separator ($1) so a preceding attribute's closing quote
+    // survives (e.g. src="x"onerror=... → src="x").
+    out = out.replace(new RegExp(`(${ATTR_SEP})on[a-z]+\\s*=\\s*"[^"]*"`, 'gi'), '$1')
+    out = out.replace(new RegExp(`(${ATTR_SEP})on[a-z]+\\s*=\\s*'[^']*'`, 'gi'), '$1')
+    out = out.replace(new RegExp(`(${ATTR_SEP})on[a-z]+\\s*=\\s*[^\\s>]+`, 'gi'), '$1')
     // Neutralize javascript:/vbscript:/data: URLs on href and src. Same
-    // separator rule as above so `<a/href=javascript:...>` is normalized.
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*")(\s*(?:javascript|vbscript|data)\s*:[^"]*)"/gi, '$1#"')
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*')(\s*(?:javascript|vbscript|data)\s*:[^']*)'/gi, "$1#'")
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*)(?!["'])(\s*(?:javascript|vbscript|data)\s*:[^\s>]*)/gi, '$1#')
+    // separator rule so quote-abutted variants are also normalized.
+    out = out.replace(new RegExp(`(${ATTR_SEP}(?:href|src|xlink:href)\\s*=\\s*")(\\s*(?:javascript|vbscript|data)\\s*:[^"]*)"`, 'gi'), '$1#"')
+    out = out.replace(new RegExp(`(${ATTR_SEP}(?:href|src|xlink:href)\\s*=\\s*')(\\s*(?:javascript|vbscript|data)\\s*:[^']*)'`, 'gi'), "$1#'")
+    out = out.replace(new RegExp(`(${ATTR_SEP}(?:href|src|xlink:href)\\s*=\\s*)(?!["'])(\\s*(?:javascript|vbscript|data)\\s*:[^\\s>]*)`, 'gi'), '$1#')
     return out
   }
 

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -566,14 +566,6 @@ const spawnScriptToLaunchInstaller = (installerPath) => {
   }
 };
 
-
-const downloadBackend = async (tag, zipPath) => {
-  const downloadUrl = `https://github.com/GovTechSG/oobee/releases/download/${tag}/oobee-portable-mac.zip`;
-  const command = `curl '${downloadUrl}' -o '${zipPath}' -L && rm -rf '${backendPath}' && mkdir '${backendPath}'`;
-
-  return execCommand(command);
-};
-
 // MacOS only
 const validateZipFile = async (zipPath) => {
   const isZipValid = async (zipPath) => {

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -72,11 +72,15 @@ const htmlNodeToReact = (node, key) => {
   return createElement(tag, props, ...children);
 };
 
+// Parse via DOMParser (inert document): unlike a live-document `<div>`,
+// resources such as `<img src>` do NOT load and inline event handlers
+// (onerror/onload/…) do NOT fire during parsing. That closes the XSS
+// window that would otherwise open before htmlNodeToReact's allowlist
+// gets a chance to strip them.
 const htmlStringToReact = (html) => {
   if (typeof html !== "string" || html.length === 0) return null;
-  const container = document.createElement("div");
-  container.innerHTML = html;
-  return Array.from(container.childNodes).map((c, i) => htmlNodeToReact(c, i));
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return Array.from(doc.body.childNodes).map((c, i) => htmlNodeToReact(c, i));
 };
 
 const WhatsNewModal = ({
@@ -109,9 +113,13 @@ const WhatsNewModal = ({
 
   // create react elements from release notes html string
   const getReleaseNotes = () => {
-    // inject parsed release notes into div element
-    const releaseNotesNode = document.createElement("div");
-    releaseNotesNode.innerHTML = releaseNotes;
+    // Parse into an inert document so <img> in the release-notes HTML
+    // doesn't kick off a network fetch and fire onerror before we walk
+    // the tree. `body` is a drop-in replacement for the previous live
+    // div; getElementsByTagName / childNodes / .innerHTML / .innerText
+    // all work the same on a DOMParser-owned element in Chromium.
+    const releaseNotesNode = new DOMParser()
+      .parseFromString(releaseNotes || "", "text/html").body;
 
     // remove unneeded info
     const allElements = releaseNotesNode.childNodes;


### PR DESCRIPTION
## Summary

Fixes the two remaining findings from the 2026-09-09 asgard rescan of `oobee-desktop@591ee20`:

| id | severity | rule | location | title |
|----|----------|------|----------|-------|
| asgard-0001 | medium (5.0) | G1.XSS | `src/MainWindow/HomePage/WhatsNewModal.jsx:75` | DOM XSS via release-catalog markdown reaching detached innerHTML in WhatsNewModal |
| asgard-0002 | info | G1.CMDI | `public/electron/updateManager.js:570` | Latent command injection via unvalidated tag in dead function downloadBackend |

## Findings + fixes

### asgard-0001 — DOM XSS via detached-but-live innerHTML

`WhatsNewModal.jsx` was assigning release-catalog HTML to `document.createElement("div").innerHTML` in two places (`htmlStringToReact`, `getReleaseNotes`). Even though the `<div>` is never appended to `document.body`, it is still owned by the live document, so Chromium loads `<img src>` and fires inline `onerror` / `onload` handlers as a side effect of the `innerHTML` assignment — **before** `htmlNodeToReact` has a chance to run its tag/attribute allowlist. That means the allowlist provides no protection against this specific vector.

**Fix:** parse via `new DOMParser().parseFromString(html, "text/html")` and walk `doc.body.childNodes` / use `doc.body` as the container node. DOMParser-produced documents are inert per HTML spec — resources are not loaded and event handlers do not fire during parsing, so the allowlist rebuild is now the only path through which attributes reach the React tree.

Also hardened the source-side sanitizer (`main.js` `sanitizeRenderedMarkdown`). The finding's PoC:

```html
<img src="x"onerror="alert(1)">
```

passed through unchanged because the `on*`-stripping regexes required a `[\s/]` separator before the attribute name. The HTML5 tokenizer treats `"onerror` (quote then letter) as a *recoverable parse error* that still creates the second attribute, so the payload was live in Chromium. Added `"` and `'` to the separator class (`ATTR_SEP`) for both the `on*` and `javascript:`/`vbscript:`/`data:` URL regexes, and preserved the captured separator via `$1` so the value-terminating quote of the preceding attribute isn't consumed.

Sanitizer verification (run against the payload set from the finding + regressions):

```
IN : <img src="x"onerror="alert(1)">          OUT: <img src="x">
IN : <img src='x'onerror='alert(1)'>          OUT: <img src='x'>
IN : <img src=x onerror=alert(1)>             OUT: <img src=x >
IN : <img src="x" onerror="alert(1)">         OUT: <img src="x" >
IN : <img/onerror=alert(1) src=x>             OUT: <img/ src=x>
IN : <a href="foo"onclick="steal()">x</a>     OUT: <a href="foo">x</a>
IN : <a href="foo"href="javascript:...">x</a> OUT: <a href="foo"href="#">x</a>
IN : <span data-onclick="x">ok</span>         OUT: <span data-onclick="x">ok</span>  (unchanged)
IN : <img src="https://.../img.png" alt="hi"> OUT: <img src="https://.../img.png" alt="hi">  (unchanged)
```

### asgard-0002 — Dead-code CMDI in `downloadBackend`

`downloadBackend(tag, zipPath)` interpolated its `tag` argument straight into a `curl ... && rm -rf ... && mkdir ...` shell string passed to `execCommand` / `child_process.exec`, without the `validateTag()` call used by the sibling `downloadAndUnzipFrontendMac`/`Windows` builders. It was neither exported (`module.exports` = `{ killChildProcess, run }`) nor referenced anywhere in the repo (confirmed by grep). Deleted rather than papered over — matches the hardening already applied to its siblings and removes the latent trap.

## Cross-platform / compatibility check

- `DOMParser` is a WHATWG standard and available in Chromium (i.e. every Electron renderer) on all supported platforms (macOS / Windows / Linux). No polyfill required.
- Behavior on empty/undefined `releaseNotes` preserved: `parseFromString("", "text/html").body` returns an empty body with no children, matching the previous `container.innerHTML = ""` behavior.
- Sanitizer changes are pure string-in-string-out regex updates — no encoding, path, or protocol assumptions.
- HTTP/HTTPS handling: unchanged. `isSafeHref` / `SAFE_URL_SCHEMES` regex not touched.

## Test plan

- [x] Verified sanitizer against all bypass variants (see table above) — payloads neutralized, negative cases preserved
- [x] Confirmed `downloadBackend` has no callers (`grep -rn` in `public/` + `src/`) and isn't in `module.exports`
- [ ] Manual: open the app, observe What's New / announcement modal renders release notes correctly (markdown → HTML → React tree via DOMParser now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)