### PR TITLE
security: parse untrusted release-notes HTML inertly and drop dead downloadBackend

### DIFF
--- a/public/electron/main.js
+++ b/public/electron/main.js
@@ -507,25 +507,31 @@ app.on('ready', async () => {
   //
   // HTML allows any of whitespace, `/`, or `=` following an attribute name,
   // so `\s+on...` alone is bypassable (e.g. `<img/onerror=alert(1) src=x>`).
-  // The event-handler and URL-scheme regexes below treat `[\s/]` as valid
-  // attribute separators before the attribute name.
+  // Per the HTML5 tokenizer, a quote immediately followed by an attribute
+  // name (e.g. `<img src="x"onerror=...>`) is a recoverable parse error that
+  // still creates a distinct attribute, so `"`/`'` must also count as valid
+  // separators. The regexes below use a lookbehind so the preceding character
+  // is checked but not consumed (consuming a closing quote would leave the
+  // prior attribute unterminated).
   const sanitizeRenderedMarkdown = (html) => {
     if (typeof html !== 'string' || html.length === 0) return ''
     let out = html
     // Drop entire dangerous elements (with their contents).
     out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[\s\S]*?<\s*\/\s*\1\s*>/gi, '')
     out = out.replace(/<\s*(script|style|iframe|object|embed|link|meta|base|form|input|textarea|button)\b[^>]*>/gi, '')
-    // Drop inline event handlers (onclick=, onerror=, ...). Match `/` or
-    // whitespace as the separator between the previous attribute/tag and
-    // the `on*` attribute name so `<img/onerror=...>` is also caught.
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*"[^"]*"/gi, ' ')
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*'[^']*'/gi, ' ')
-    out = out.replace(/[\s/]+on[a-z]+\s*=\s*[^\s>]+/gi, ' ')
+    // Drop inline event handlers (onclick=, onerror=, ...). Match against a
+    // preceding whitespace, `/`, `"`, or `'` via lookbehind so both
+    // `<img/onerror=...>` and `<img src="x"onerror=...>` are caught without
+    // consuming the closing quote of the previous attribute.
+    out = out.replace(/(?<=[\s/"'])on[a-z]+\s*=\s*"[^"]*"/gi, ' ')
+    out = out.replace(/(?<=[\s/"'])on[a-z]+\s*=\s*'[^']*'/gi, ' ')
+    out = out.replace(/(?<=[\s/"'])on[a-z]+\s*=\s*[^\s>]+/gi, ' ')
     // Neutralize javascript:/vbscript:/data: URLs on href and src. Same
-    // separator rule as above so `<a/href=javascript:...>` is normalized.
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*")(\s*(?:javascript|vbscript|data)\s*:[^"]*)"/gi, '$1#"')
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*')(\s*(?:javascript|vbscript|data)\s*:[^']*)'/gi, "$1#'")
-    out = out.replace(/([\s/](?:href|src|xlink:href)\s*=\s*)(?!["'])(\s*(?:javascript|vbscript|data)\s*:[^\s>]*)/gi, '$1#')
+    // lookbehind treatment so `<a/href=javascript:...>` and
+    // `<a title="x"href=javascript:...>` are both normalized.
+    out = out.replace(/((?<=[\s/"'])(?:href|src|xlink:href)\s*=\s*")(\s*(?:javascript|vbscript|data)\s*:[^"]*)"/gi, '$1#"')
+    out = out.replace(/((?<=[\s/"'])(?:href|src|xlink:href)\s*=\s*')(\s*(?:javascript|vbscript|data)\s*:[^']*)'/gi, "$1#'")
+    out = out.replace(/((?<=[\s/"'])(?:href|src|xlink:href)\s*=\s*)(?!["'])(\s*(?:javascript|vbscript|data)\s*:[^\s>]*)/gi, '$1#')
     return out
   }
 

--- a/public/electron/updateManager.js
+++ b/public/electron/updateManager.js
@@ -567,13 +567,6 @@ const spawnScriptToLaunchInstaller = (installerPath) => {
 };
 
 
-const downloadBackend = async (tag, zipPath) => {
-  const downloadUrl = `https://github.com/GovTechSG/oobee/releases/download/${tag}/oobee-portable-mac.zip`;
-  const command = `curl '${downloadUrl}' -o '${zipPath}' -L && rm -rf '${backendPath}' && mkdir '${backendPath}'`;
-
-  return execCommand(command);
-};
-
 // MacOS only
 const validateZipFile = async (zipPath) => {
   const isZipValid = async (zipPath) => {

--- a/src/MainWindow/HomePage/WhatsNewModal.jsx
+++ b/src/MainWindow/HomePage/WhatsNewModal.jsx
@@ -72,11 +72,15 @@ const htmlNodeToReact = (node, key) => {
   return createElement(tag, props, ...children);
 };
 
+// Parse untrusted HTML with DOMParser so the resulting document is inert:
+// <img>/<iframe>/etc. resources do not load and inline event handlers
+// (onerror/onload) do not fire during parsing. Assigning the same HTML to a
+// live document's innerHTML would fire those side-effects before the
+// allowlist rebuild below can strip the attributes.
 const htmlStringToReact = (html) => {
   if (typeof html !== "string" || html.length === 0) return null;
-  const container = document.createElement("div");
-  container.innerHTML = html;
-  return Array.from(container.childNodes).map((c, i) => htmlNodeToReact(c, i));
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return Array.from(doc.body.childNodes).map((c, i) => htmlNodeToReact(c, i));
 };
 
 const WhatsNewModal = ({
@@ -109,9 +113,11 @@ const WhatsNewModal = ({
 
   // create react elements from release notes html string
   const getReleaseNotes = () => {
-    // inject parsed release notes into div element
-    const releaseNotesNode = document.createElement("div");
-    releaseNotesNode.innerHTML = releaseNotes;
+    // Parse into an inert document (same reasoning as htmlStringToReact) so
+    // any image/handler side-effects in untrusted release-notes HTML do not
+    // fire before we slice out the h4/ul sections below.
+    const doc = new DOMParser().parseFromString(releaseNotes, "text/html");
+    const releaseNotesNode = doc.body;
 
     // remove unneeded info
     const allElements = releaseNotesNode.childNodes;


### PR DESCRIPTION
## Summary
Addresses asgard 2026-09-09 3pm rescan findings on `oobee-desktop@591ee20`.

- **asgard-0001 (medium, DOM XSS)** — `WhatsNewModal` was assigning untrusted, sanitizer-bypassable release-notes/announcement HTML to a live document `<div>`'s `innerHTML`. Blink starts loading `<img>` elements and fires inline event handlers (`onerror`/`onload`) as a side effect of the assignment, *before* the tag/attribute allowlist rebuild in `htmlNodeToReact` can inspect the tree. Both `htmlStringToReact` and `getReleaseNotes` now parse via `new DOMParser().parseFromString(html, "text/html")`, which produces an inert document (no resource loading, no handler execution) that the existing allowlist rebuild walks safely.
- **Defense-in-depth** — hardened `sanitizeRenderedMarkdown` in `main.js`. The event-handler and `javascript:`/`vbscript:`/`data:` URL regexes required `[\s/]` before the attribute name, so `<img src="x"onerror="alert(1)">` (quote-abutted, a recoverable HTML5-tokenizer parse error that still creates a distinct attribute) passed through unchanged. Switched to a lookbehind that also treats `"`/`'` as valid separators, without consuming the closing quote of the preceding attribute.
- **asgard-0002 (info, latent CMDI)** — deleted unused `downloadBackend()` in `updateManager.js`. It interpolated an unvalidated `tag` directly into a `curl`/`rm`/`mkdir` shell string passed to `child_process.exec`. Not currently reachable (not exported, no call sites in the repo), but would have become an OS command injection the moment it was wired to a catalog-derived tag.

## Test plan
- [x] Sanitizer regex verified against 10 XSS payloads including all documented bypass variants (`<img src="x"onerror=...>`, `<img/onerror=...>`, `<a title="x"href="javascript:...">`, etc.) — all now stripped without corrupting adjacent attributes.
- [x] `DOMParser` change verified against the real `docs/latest-release.json` — top-level `childNodes` counts match `div.innerHTML` exactly for both `latestReleaseNotes` (22) and `latestPreReleaseNotes` (16), so this is a drop-in replacement for the render path.
- [x] Confirmed the parsed document is inert (`defaultView === null`) — even a surviving `<img onerror="...">` does not execute during parsing.
- [x] `grep`'d the repo for `downloadBackend`: 0 remaining references after deletion.
- [ ] Smoke-test the What's-New modal on first launch after an update to confirm release notes still render.
- [ ] Smoke-test the announcement modal when `alwaysShowAnnouncement` is populated in the release catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)